### PR TITLE
Switch to Scatchpad/ScratchpadRevision system from ScratchCode system

### DIFF
--- a/js/play-ui.js
+++ b/js/play-ui.js
@@ -94,7 +94,7 @@ $(function(){
 		$("#save-share-code").bind( "buttonClick", function() {
 			$(this).addClass( "ui-state-disabled" );
 		
-			saveScratchpadRevision(function( scratchpad ) {
+			saveScratchpadRevision(function(scratchpad) {
 				window.location.href = "/labs/code/" + scratchpad.slug +
 					"/" + scratchpad.id;
 			});
@@ -310,24 +310,24 @@ $(function(){
 				"*defaultRoute"       : "defaultRoute"
 			},
 			scratchpadNew: function() {
-				curProblem = { id: 1 };
+				curProblem = {id: 1};
 				
 				Exercise = {
 					id: 0,
 					scratchpad: {},
 					revision: {},
-					problems: [ curProblem ]
+					problems: [curProblem]
 				};
 				
-				loadResults( Exercise, startScratch );
+				loadResults(Exercise, startScratch);
 			},
 			scratchpadShowLatest: function(slug, scratchpadId) {
 				scratchpadId = parseInt(scratchpadId, 10);
 				
-				getScratchpad( scratchpadId, function( scratchpad ) {
+				getScratchpad(scratchpadId, function(scratchpad) {
 					var revision = scratchpad.latest_revision;
 					
-					curProblem = { id: 1, answer: revision.code };
+					curProblem = {id: 1, answer: revision.code};
 					
 					Exercise.scratchpad = scratchpad;
 					Exercise.revision = revision;
@@ -341,18 +341,18 @@ $(function(){
 					//
 					// TODO(jlfwong): Remove this, make all accesses explicitly
 					// to Exercise.revision or Exercise.scratchpad
-					_.extend( Exercise, revision, scratchpad );
+					$.extend(Exercise, revision, scratchpad);
 					
 					// If an audio track is provided, load the track data
 					// and load the audio player as well
-					if ( Exercise.audio_id ) {
-						connectAudio(function( data ) {
+					if (Exercise.audio_id) {
+						connectAudio(function(data) {
 							track = data;
 							audioInit();
 						});
 					}
 					
-					Exercise.problems = [ curProblem ];
+					Exercise.problems = [curProblem];
 					
 					startScratch();
 				});

--- a/js/record-ui.js
+++ b/js/record-ui.js
@@ -126,7 +126,7 @@ $(function(){
 				return;
 			}
 			
-			saveScratchpadRevision(function( scratchpad ) {
+			saveScratchpadRevision(function(scratchpad) {
 				dialog.dialog( "close" );
 				window.location.href = "/labs/code/" + scratchpad.slug +
 					"/" + scratchpad.id;

--- a/js/utils.js
+++ b/js/utils.js
@@ -298,7 +298,7 @@ var saveExercise = function( callback ) {
 	});		
 };
 
-var getScratchpad = function( scratchpadId, callback ) {
+var getScratchpad = function(scratchpadId, callback) {
 	// TODO(jlfwong): Error handling (404)
 	var scratchpadUrl = "/api/labs/scratchpads/" + scratchpadId;
 	
@@ -313,7 +313,7 @@ var serializeRevisionData = function() {
 	};
 };
 
-var saveRevision = function( scratchpadId, callback ) {
+var saveRevision = function(scratchpadId, callback) {
 	$.ajax({
 		type: "POST",
 		url: "/api/labs/scratchpads/" + scratchpadId + "/revisions/",
@@ -324,7 +324,7 @@ var saveRevision = function( scratchpadId, callback ) {
 	});
 };
 
-var saveScratchpadRevision = function( callback ) {
+var saveScratchpadRevision = function(callback) {
 	// TODO(jlfwong): Error handling
 	
 	// TODO(jlfwong): If the current user is the owner of the scratchpad, give
@@ -352,11 +352,11 @@ var saveScratchpadRevision = function( callback ) {
 				revision: serializeRevisionData()
 			}),
 			success: callback
-		});	
+		});
 	} else {
 		// Update an existing scratchpad
-		saveRevision( currentScratchpad.id, function( revisionData ) {
-			callback( _.extend( {}, currentScratchpad, {
+		saveRevision(currentScratchpad.id, function(revisionData) {
+			callback($.extend({}, currentScratchpad, {
 				revision: revisionData
 			}));
 		});


### PR DESCRIPTION
The behaviour of the save button is now as follows:
1. If it's a new scratchpad (i.e. URL is /labs/code), create a new scratchpad
   and revision with no origin_revision_id and create a the first revision
2. If it's a pre-existing scratchpad
   
   a) If the user is anonymous, the scratchpad is forked (new scratchpad, new
     revision, origin_id set.)
   
   b) If the user is logged in, the scratchpad is updated (new revision only) if
     the user owns the scratchpad, forked otherwise
