### PR TITLE
Rough attempt to run time trial for the code in the background (see #139)

### DIFF
--- a/js/worker.js
+++ b/js/worker.js
@@ -1,0 +1,38 @@
+var stubFunctions = function(context) {
+	var functionStubbed = {};
+	for ( var prop in context ) {
+		if (!context.hasOwnProperty(prop)) {
+			continue;
+		}
+		
+		// Stub out functions
+		if (context[prop] === '__STUBBED_FUNCTION__') {
+			functionStubbed[prop] = function() {};
+		} else {
+			functionStubbed[prop] = context[prop];
+		}
+	}
+	return functionStubbed;
+};
+
+self.onmessage = function(event) {
+	var data = event.data;
+	var code = data.code;
+	var globalContext = stubFunctions(data.globalContext);
+	var contexts = data.contexts.map(stubFunctions);
+
+	/*
+	self.postMessage({
+		type: 'start'
+	});
+	self.postMessage({
+		type: 'log',
+		message: data.contexts
+	});
+	*/
+	(new Function( code )).apply( globalContext, contexts );
+	contexts[0].draw && contexts[0].draw();
+	self.postMessage({
+		type: 'end'
+	});
+};


### PR DESCRIPTION
**DO NOT MERGE**

This is my work trying to catch infinite loops from blocking the UI thread whenever Web Workers are available.

There are a few blockers that prevent this from being really viable to merge at the moment.

The major problem is that this is currently only working with `Output.exec` because `Output.runCode` assumes `exec` is synchronous - the introduction of time trial testing with a background thread makes it async.

I'm also not totally clear how the injection process with `fnCalls.push` works - so if I do use `runCode`, then the second timeTrial won't work, because `fnCalls` is not defined in the worker thread.

Only using `exec` instead of `runCode` makes a lot of things not work as they should in the editor (which is why runCode was introduced in the first place, I'm guessing).
