### PR TITLE
Update output_pjs_deps.js to include PVector (set) fix

### DIFF
--- a/build/js/live-editor.output_pjs_deps.js
+++ b/build/js/live-editor.output_pjs_deps.js
@@ -17402,7 +17402,6 @@
     // test program.  The reason why this bug ddoesn't appear when using just 
     // the canvas is that the canvas doesn't get "mousemove" events which occur
     // outside the canvas.
-    // TODO(kevinb7): verify that this solution works with just the canvas
     var mouseOverOccurredFlag = false;
     attachEventHandler(curElement, "mousemove", function(e) {
       if (mouseOverOccurredFlag) {


### PR DESCRIPTION
The changes to the mouse handlers come from previous commits to processing-js to support the debugger.