### PR TITLE
automate tests with travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ before_script:
   - npm install -g bower
   - bower install
 script:
+  - npm run build
   - ./node_modules/.bin/testee tests/output/pjs/index.html
   - ./node_modules/.bin/testee tests/output/webpage/index.html
   - ./node_modules/.bin/testee tests/tooltips/index.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+node_js:
+  - "0.10"
+before_script:
+  - npm install -g bower
+  - bower install
+script:
+  - ./node_modules/.bin/testee tests/output/pjs/index.html
+  - ./node_modules/.bin/testee tests/output/webpage/index.html
+  - ./node_modules/.bin/testee tests/tooltips/index.html

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -197,5 +197,7 @@ gulp.task("test", function(callback) {
     runSequence("test_output_pjs", "test_output_webpage", "test_tooltips", callback);
 });
 
-gulp.task("default", ["watch", "templates", "scripts", "workers", "styles",
-    "images", "externals"]);
+gulp.task("build",
+    ["templates", "scripts", "workers", "styles", "images", "externals"]);
+
+gulp.task("default", ["watch", "build"]);

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Live Code Editor",
   "main": "dist/live-editor.js",
   "scripts": {
+    "build": "gulp build",
     "test": "gulp test"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "async": "^0.9.0",
     "request": "^2.44.0",
     "sinon": "^1.10.3",
+    "testee": "^0.1.8",
     "handlebars": "1.0.5-beta",
     "gulp-bower": "0.0.7",
     "gulp-symlink": "^2.0.1"

--- a/tests/output/debugger/index.html
+++ b/tests/output/debugger/index.html
@@ -45,6 +45,7 @@
         <script src="../../../build/js/live-editor.output_debugger_deps.js"></script>
         <script src="../../../node_modules/mocha/mocha.js"></script>
         <script src="../../../node_modules/expect.js/index.js"></script>
+        <script src="../../sinon.js"></script>
         <script>mocha.setup("bdd");</script>
         <script src="../pjs/test_utils.js"></script>
         <script src="../pjs/output_test.js"></script>

--- a/tests/output/pjs/output_test.js
+++ b/tests/output/pjs/output_test.js
@@ -643,6 +643,9 @@ describe("Scratchpad Output Exec", function() {
             Program.restart();
         },
         errors: [],
+        // p.Program methods weren't being stubbed and were causing some of the
+        // test code to be run in an infinite loop after the it() block had 
+        // completed.
         setup: function(output) {
             var p = output.output.canvas;
             sinon.stub(p.Program, "settings");

--- a/tests/output/pjs/output_test.js
+++ b/tests/output/pjs/output_test.js
@@ -644,7 +644,7 @@ describe("Scratchpad Output Exec", function() {
         },
         errors: [],
         // p.Program methods weren't being stubbed and were causing some of the
-        // test code to be run in an infinite loop after the it() block had 
+        // test code to be run in an infinite loop after the it() block had
         // completed.
         setup: function(output) {
             var p = output.output.canvas;

--- a/tests/output/pjs/output_test.js
+++ b/tests/output/pjs/output_test.js
@@ -637,11 +637,24 @@ describe("Scratchpad Output Exec", function() {
     runTest({
         title: "Program functions exist",
         code: function() {
-            var x = Program.settings();
+            Program.settings();
+            Program.restart();
             Program.runTests(function() {});
             Program.restart();
         },
-        errors: []
+        errors: [],
+        setup: function(output) {
+            var p = output.output.canvas;
+            sinon.stub(p.Program, "settings");
+            sinon.stub(p.Program, "restart");
+            sinon.stub(p.Program, "runTests");
+        },
+        teardown: function(output) {
+            var p = output.output.canvas;
+            expect(p.Program.settings.calledWith()).to.be(true);
+            expect(p.Program.restart.calledWith()).to.be(true);
+            expect(p.Program.runTests.calledWith()).to.be(true);
+        }
     });
 
     runTest({

--- a/tests/output/sql/index.html
+++ b/tests/output/sql/index.html
@@ -36,11 +36,13 @@
         <script src="output_test.js"></script>
         <script src="assert_test.js"></script>
         <script>
-            if (window.mochaPhantomJS) {
-                mochaPhantomJS.run();
-            } else {
-                mocha.run();
-            }
+            onload = function(){
+                if (window.mochaPhantomJS) {
+                    mochaPhantomJS.run();
+                } else {
+                    mocha.run();
+                }
+            };
         </script>
     </body>
 </html>

--- a/tests/tooltips/index.html
+++ b/tests/tooltips/index.html
@@ -43,11 +43,13 @@
         <script src="colorPicker_test.js"></script>
         <script src="tooltips_test.js"></script>
         <script>
-            if (window.mochaPhantomJS) {
-                mochaPhantomJS.run();
-            } else {
-                mocha.run();
-            }
+            onload = function(){
+                if (window.mochaPhantomJS) {
+                    mochaPhantomJS.run();
+                } else {
+                    mocha.run();
+                }
+            };
         </script>
     </body>
 </html>


### PR DESCRIPTION
I was trying to get this working so that we could run the tests in Chrome on travis-ci, but for some reason the test runner won't start Chrome in that environment (works fine on OS X).  When I have more time I'll set up an ubuntu virtual machine and see if I can figure out what's going on.  In the meantime though, I've automated the tests that I can using phantomjs.  You'll have to enable access on travis-ci to khan/live-editor.