### PR TITLE
Toggle autosuggest via keyboard shortcut

### DIFF
--- a/js/editors/ace/editor-ace.js
+++ b/js/editors/ace/editor-ace.js
@@ -53,9 +53,10 @@ window.AceEditor = Backbone.View.extend({
             imagesDir: options.imagesDir,
             soundsDir: options.soundsDir,
             editor: this.editor,
-            record: this.record
+            record: this.record,
+            enabled: window.localStorage['autosuggest'] || true
         });
-        
+
         this.tooltipEngine.on("scrubbingStarted", function(name) {
             this.trigger("scrubbingStarted", name);
         }.bind(this));
@@ -391,7 +392,7 @@ window.AceEditor = Backbone.View.extend({
         var doc = this.editor.getSession().getDocument();
 
         return {
-            start: doc.positionToIndex(rng.start), 
+            start: doc.positionToIndex(rng.start),
             end: doc.positionToIndex(rng.end)
         };
     },

--- a/js/editors/ace/editor-ace.js
+++ b/js/editors/ace/editor-ace.js
@@ -53,8 +53,7 @@ window.AceEditor = Backbone.View.extend({
             imagesDir: options.imagesDir,
             soundsDir: options.soundsDir,
             editor: this.editor,
-            record: this.record,
-            enabled: window.localStorage['autosuggest'] || true
+            record: this.record
         });
 
         this.tooltipEngine.on("scrubbingStarted", function(name) {

--- a/js/live-editor.js
+++ b/js/live-editor.js
@@ -112,10 +112,11 @@ window.LiveEditor = Backbone.View.extend({
             type: this.editorType
         });
 
-        // Looks to see if "autosuggest=no" is in the url,
+        // Looks to see if "autosuggestToggle=yes" is in the url,
         //  if it is, then we disable the live autosuggestions.
         if (window.location.search.indexOf("autosuggestToggle=yes") !== -1) {
             var tooltipEngine = this.config.editor.tooltipEngine;
+            window.localStorage["autosuggest"] = "true";
 
             // Allows toggling of the autosuggestions.
             this.editor.editor.commands.addCommand({
@@ -129,7 +130,7 @@ window.LiveEditor = Backbone.View.extend({
 
                     tooltipEngine.setEnabledStatus(status !== true);
 
-                    window.localStorage.setItem("autosuggest", status !== true);
+                    window.localStorage.setItem("autosuggest", String(status !== true));
                 }
             });
         } else {

--- a/js/live-editor.js
+++ b/js/live-editor.js
@@ -116,7 +116,11 @@ window.LiveEditor = Backbone.View.extend({
         //  if it is, then we disable the live autosuggestions.
         if (window.location.search.indexOf("autosuggestToggle=yes") !== -1) {
             var tooltipEngine = this.config.editor.tooltipEngine;
+
+            // Overrides whatever is in localStorage.
+            // TODO (anyone) remove this when the URL param is removed.
             window.localStorage["autosuggest"] = "true";
+
             // Allows toggling of the autosuggestions.
             this.editor.editor.commands.addCommand({
                 name: 'toggleAutosuggest',

--- a/js/live-editor.js
+++ b/js/live-editor.js
@@ -114,7 +114,7 @@ window.LiveEditor = Backbone.View.extend({
 
         // Looks to see if "autosuggest=no" is in the url,
         //  if it is, then we disable the live autosuggestions.
-        if (window.location.search.indexOf("experimental=yes") !== -1) {
+        if (window.location.search.indexOf("autosuggestToggle=yes") !== -1) {
             var tooltipEngine = this.config.editor.tooltipEngine;
 
             // Allows toggling of the autosuggestions.

--- a/js/live-editor.js
+++ b/js/live-editor.js
@@ -125,9 +125,9 @@ window.LiveEditor = Backbone.View.extend({
             exec: function(editor) {
                 var status = window.localStorage["autosuggest"] === "true";
 
-                tooltipEngine.setEnabledStatus(status === false);
+                tooltipEngine.setEnabledStatus(status !== true);
 
-                window.localStorage.setItem("autosuggest", status === false);
+                window.localStorage.setItem("autosuggest", status !== true);
             }
         });
 

--- a/js/live-editor.js
+++ b/js/live-editor.js
@@ -116,7 +116,6 @@ window.LiveEditor = Backbone.View.extend({
         //  if it is, then we disable the live autosuggestions.
         if (window.location.search.indexOf("autosuggestToggle=yes") !== -1) {
             var tooltipEngine = this.config.editor.tooltipEngine;
-            window.localStorage["autosuggest"] = "true";
 
             // Allows toggling of the autosuggestions.
             this.editor.editor.commands.addCommand({

--- a/js/live-editor.js
+++ b/js/live-editor.js
@@ -112,29 +112,30 @@ window.LiveEditor = Backbone.View.extend({
             type: this.editorType
         });
 
-        var tooltipEngine = this.config.editor.tooltipEngine;
-
         // Looks to see if "autosuggest=no" is in the url,
         //  if it is, then we disable the live autosuggestions.
-        if (window.location.search.indexOf("autosuggest=no") !== -1) {
-            tooltipEngine.setEnabledStatus(false);
+        if (window.location.search.indexOf("experimental=yes") !== -1) {
+            var tooltipEngine = this.config.editor.tooltipEngine;
+
+            // Allows toggling of the autosuggestions.
+            this.editor.editor.commands.addCommand({
+                name: 'toggleAutosuggest',
+                bindKey: {
+                    win: 'Ctrl+Alt+A',
+                    mac: 'Command+Option+A'
+                },
+                exec: function(editor) {
+                    var status = window.localStorage["autosuggest"] === "true";
+
+                    tooltipEngine.setEnabledStatus(status !== true);
+
+                    window.localStorage.setItem("autosuggest", status !== true);
+                }
+            });
+        } else {
+            // since we load the enabled value from localStorage...
+            this.config.editor.tooltipEngine.setEnabledStatus("true");
         }
-
-        // The following code adds a keystroke to toggle the autosuggesting.
-        // this.editor.editor.commands.addCommand({
-        //     name: 'toggleAutosuggest',
-        //     bindKey: {
-        //         win: 'Ctrl+Alt+A',
-        //         mac: 'Command+Option+A'
-        //     },
-        //     exec: function(editor) {
-        //         var status = window.localStorage["autosuggest"] === "true";
-
-        //         tooltipEngine.setEnabledStatus(status !== true);
-
-        //         window.localStorage.setItem("autosuggest", status !== true);
-        //     }
-        // });
 
         // linting in the webpage environment generates slowparseResults which
         // is used in the runCode step so skipping linting won't work in that

--- a/js/live-editor.js
+++ b/js/live-editor.js
@@ -116,7 +116,7 @@ window.LiveEditor = Backbone.View.extend({
         //  if it is, then we disable the live autosuggestions.
         if (window.location.search.indexOf("autosuggestToggle=yes") !== -1) {
             var tooltipEngine = this.config.editor.tooltipEngine;
-
+            window.localStorage["autosuggest"] = "true";
             // Allows toggling of the autosuggestions.
             this.editor.editor.commands.addCommand({
                 name: 'toggleAutosuggest',

--- a/js/live-editor.js
+++ b/js/live-editor.js
@@ -112,8 +112,29 @@ window.LiveEditor = Backbone.View.extend({
             type: this.editorType
         });
 
-        // linting in the webpage environment generates slowparseResults which 
-        // is used in the runCode step so skipping linting won't work in that 
+        // The following code adds a keystroke to toggle the autosuggesting.
+        // BLAME @GigabyteGiant
+        var tooltipEngine = this.config.editor.tooltipEngine;
+
+        // Adds a keyboard shortcut to the ace-editor.
+        this.editor.editor.commands.addCommand({
+            name: 'toggleAutosuggest',
+            bindKey: {
+                win: 'Ctrl+Alt+A',
+                mac: 'Command+Option+A'
+            },
+            exec: function(editor) {
+                var status = Boolean(tooltipEngine.enabled);
+                status = !status;
+
+                tooltipEngine.setEnabledStatus(status);
+
+                window.localStorage['autosuggest'] = status;
+            }
+        });
+
+        // linting in the webpage environment generates slowparseResults which
+        // is used in the runCode step so skipping linting won't work in that
         // environment without some more work
         if (this.editorType === "ace_pjs") {
             this.noLint = false;
@@ -244,7 +265,7 @@ window.LiveEditor = Backbone.View.extend({
                         });
                     }
                     self.editor.once("changeCursor", cursorDirty);
-                }, 0);                
+                }, 0);
             }
         };
         this.editor.once("changeCursor", cursorDirty);
@@ -454,7 +475,7 @@ window.LiveEditor = Backbone.View.extend({
             // Sometimes when Flash is blocked or the browser is slower,
             //  soundManager will fail to initialize at first,
             //  claiming no response from the Flash file.
-            // To handle that, we attempt a reboot 3 seconds after each 
+            // To handle that, we attempt a reboot 3 seconds after each
             //  timeout, clearing the timer if we get an onready during
             //  that time (which happens if user un-blocks flash).
             onready: function() {
@@ -571,7 +592,7 @@ window.LiveEditor = Backbone.View.extend({
 
     audioReadyToPlay: function() {
         // NOTE(pamela): We can't just check bytesLoaded,
-        //  because IE reports null for that 
+        //  because IE reports null for that
         // (it seems to not get the progress event)
         // So we've changed it to also check loaded.
         // If we need to, we can reach inside the HTML5 audio element
@@ -997,7 +1018,7 @@ window.LiveEditor = Backbone.View.extend({
         if (data.validate != null) {
             this.validation = data.validate;
         }
-        
+
         if (data.results) {
             this.trigger("runDone");
         }
@@ -1011,13 +1032,13 @@ window.LiveEditor = Backbone.View.extend({
             }.bind(this));
 
             var annotations = [];
-            for (var i = 0; i < data.results.assertions.length; i++) { 
+            for (var i = 0; i < data.results.assertions.length; i++) {
                 var unitTest = data.results.assertions[i];
                 annotations.push({
-                    row: unitTest.row, 
-                    column: unitTest.column, 
+                    row: unitTest.row,
+                    column: unitTest.column,
                     text: unitTest.text,
-                    type: "warning" 
+                    type: "warning"
                 });
                 // Underline the problem line to make it more obvious
                 //  if they don't notice the gutter icon
@@ -1080,7 +1101,7 @@ window.LiveEditor = Backbone.View.extend({
      *
      * A note about the throttling:
      * This limits updates to 50FPS. No point in updating faster than that.
-     * 
+     *
      * DO NOT CALL THIS DIRECTLY
      * Instead call markDirty because it will handle
      * throttling requests properly.
@@ -1106,7 +1127,7 @@ window.LiveEditor = Backbone.View.extend({
 
         this.postFrame(options);
     }, 20),
-    
+
     markDirty: function() {
         // They're typing. Hide the tipbar to give them a chance to fix things up
         this.tipbar.hide();
@@ -1175,7 +1196,7 @@ window.LiveEditor = Backbone.View.extend({
         // Unbind any handlers this function may have set for previous
         // screenshots
         $(window).off("message.getScreenshot");
-    
+
         // We're only expecting one screenshot back
         $(window).on("message.getScreenshot", function(e) {
             // Only call if the data is actually an image!
@@ -1183,7 +1204,7 @@ window.LiveEditor = Backbone.View.extend({
                 callback(e.originalEvent.data);
             }
         });
-    
+
         // Ask the frame for a screenshot
         this.postFrame({ screenshot: true });
     },

--- a/js/live-editor.js
+++ b/js/live-editor.js
@@ -112,35 +112,29 @@ window.LiveEditor = Backbone.View.extend({
             type: this.editorType
         });
 
-        // The following code adds a keystroke to toggle the autosuggesting.
         var tooltipEngine = this.config.editor.tooltipEngine;
 
-        // Adds a keyboard shortcut to the ace-editor.
-        this.editor.editor.commands.addCommand({
-            name: 'toggleAutosuggest',
-            bindKey: {
-                win: 'Ctrl+Alt+A',
-                mac: 'Command+Option+A'
-            },
-            exec: function(editor) {
-                var status = window.localStorage["autosuggest"] === "true";
+        // Looks to see if "autosuggest=no" is in the url,
+        //  if it is, then we disable the live autosuggestions.
+        if (window.location.search.indexOf("autosuggest=no") !== -1) {
+            tooltipEngine.setEnabledStatus(false);
+        }
 
-                tooltipEngine.setEnabledStatus(status !== true);
+        // The following code adds a keystroke to toggle the autosuggesting.
+        // this.editor.editor.commands.addCommand({
+        //     name: 'toggleAutosuggest',
+        //     bindKey: {
+        //         win: 'Ctrl+Alt+A',
+        //         mac: 'Command+Option+A'
+        //     },
+        //     exec: function(editor) {
+        //         var status = window.localStorage["autosuggest"] === "true";
 
-                window.localStorage.setItem("autosuggest", status !== true);
-            }
-        });
+        //         tooltipEngine.setEnabledStatus(status !== true);
 
-        this.editor.editor.commands.addCommand({
-            name: 'showSettingsMenu',
-            bindKey: {
-                win: 'Ctrl+Alt+M',
-                mac: 'Ctrl+Option+M'
-            },
-            exec: function(editor) {
-                
-            }
-        });
+        //         window.localStorage.setItem("autosuggest", status !== true);
+        //     }
+        // });
 
         // linting in the webpage environment generates slowparseResults which
         // is used in the runCode step so skipping linting won't work in that

--- a/js/live-editor.js
+++ b/js/live-editor.js
@@ -129,7 +129,7 @@ window.LiveEditor = Backbone.View.extend({
 
                 tooltipEngine.setEnabledStatus(status);
 
-                window.localStorage['autosuggest'] = status;
+                window.localStorage.setItem("autosuggest", status);
             }
         });
 

--- a/js/live-editor.js
+++ b/js/live-editor.js
@@ -124,12 +124,11 @@ window.LiveEditor = Backbone.View.extend({
                 mac: 'Command+Option+A'
             },
             exec: function(editor) {
-                var status = Boolean(tooltipEngine.enabled);
-                status = !status;
+                var status = window.localStorage["autosuggest"] === "true";
+                
+                tooltipEngine.setEnabledStatus(status === false);
 
-                tooltipEngine.setEnabledStatus(status);
-
-                window.localStorage.setItem("autosuggest", status);
+                window.localStorage.setItem("autosuggest", status === false);
             }
         });
 

--- a/js/live-editor.js
+++ b/js/live-editor.js
@@ -113,7 +113,6 @@ window.LiveEditor = Backbone.View.extend({
         });
 
         // The following code adds a keystroke to toggle the autosuggesting.
-        // BLAME @GigabyteGiant
         var tooltipEngine = this.config.editor.tooltipEngine;
 
         // Adds a keyboard shortcut to the ace-editor.
@@ -125,10 +124,21 @@ window.LiveEditor = Backbone.View.extend({
             },
             exec: function(editor) {
                 var status = window.localStorage["autosuggest"] === "true";
-                
+
                 tooltipEngine.setEnabledStatus(status === false);
 
                 window.localStorage.setItem("autosuggest", status === false);
+            }
+        });
+
+        this.editor.editor.commands.addCommand({
+            name: 'showSettingsMenu',
+            bindKey: {
+                win: 'Ctrl+Alt+M',
+                mac: 'Ctrl+Option+M'
+            },
+            exec: function(editor) {
+                
             }
         });
 

--- a/js/ui/autosuggest.js
+++ b/js/ui/autosuggest.js
@@ -10,6 +10,7 @@ window.ScratchpadAutosuggest = {
     init: function(editor) {
         this.initialized = true;
         this.editor = editor;
+        // TODO @GigabyteGiant load value from localStorage.
         this.enableLiveCompletion(true);
         var langTools = ace.require("ace/ext/language_tools");
 

--- a/js/ui/autosuggest.js
+++ b/js/ui/autosuggest.js
@@ -10,7 +10,6 @@ window.ScratchpadAutosuggest = {
     init: function(editor) {
         this.initialized = true;
         this.editor = editor;
-        // TODO @GigabyteGiant load value from localStorage.
         this.enableLiveCompletion(window.localStorage["autosuggest"] || true);
         var langTools = ace.require("ace/ext/language_tools");
 

--- a/js/ui/autosuggest.js
+++ b/js/ui/autosuggest.js
@@ -11,7 +11,7 @@ window.ScratchpadAutosuggest = {
         this.initialized = true;
         this.editor = editor;
         // TODO @GigabyteGiant load value from localStorage.
-        this.enableLiveCompletion(true);
+        this.enableLiveCompletion(window.localStorage["autosuggest"] || true);
         var langTools = ace.require("ace/ext/language_tools");
 
         var customCompleters = [ScratchpadAutosuggestData._keywords,

--- a/js/ui/tooltip-engine.js
+++ b/js/ui/tooltip-engine.js
@@ -2,7 +2,7 @@ window.TooltipEngine = Backbone.View.extend({
     initialize: function(options) {
         this.options = options;
         this.editor = options.editor;
-        this.enabled = "true";
+        this.enabled = true;
         var record = this.options.record;
 
         this.tooltips = {};
@@ -93,7 +93,7 @@ window.TooltipEngine = Backbone.View.extend({
 
 
         this.requestTooltipDefaultCallback = function() {  //Fallback to hiding
-            ScratchpadAutosuggest.enableLiveCompletion(this.enabled === "true");
+            ScratchpadAutosuggest.enableLiveCompletion(this.enabled);
             if (this.currentTooltip && this.currentTooltip.$el) {
                 this.currentTooltip.$el.hide();
                 this.currentTooltip = undefined;

--- a/js/ui/tooltip-engine.js
+++ b/js/ui/tooltip-engine.js
@@ -2,7 +2,7 @@ window.TooltipEngine = Backbone.View.extend({
     initialize: function(options) {
         this.options = options;
         this.editor = options.editor;
-        this.enabled = (window.localStorage['autosuggest']);
+        this.enabled = (window.localStorage['autosuggest'] || true);
         var record = this.options.record;
 
         this.tooltips = {};

--- a/js/ui/tooltip-engine.js
+++ b/js/ui/tooltip-engine.js
@@ -2,6 +2,7 @@ window.TooltipEngine = Backbone.View.extend({
     initialize: function(options) {
         this.options = options;
         this.editor = options.editor;
+        this.enabled = options.enabled;
         var record = this.options.record;
 
         this.tooltips = {};
@@ -56,7 +57,9 @@ window.TooltipEngine = Backbone.View.extend({
             target: this.editor.session.getDocument(),
             event: "change",
             fn: function(e) {
-                this.doRequestTooltip(e.data);
+                if (this.enabled) {
+                    this.doRequestTooltip(e.data);
+                }
             }.bind(this)
         }, {
             target: this.editor.session,
@@ -88,16 +91,23 @@ window.TooltipEngine = Backbone.View.extend({
             cb.target.on(cb.event, cb.fn);
         });
 
-        
+
         this.requestTooltipDefaultCallback = function() {  //Fallback to hiding
-            ScratchpadAutosuggest.enableLiveCompletion(true);
+            // TODO (@GigabyteGiant) perhaps figure out a better way to do this?
+            // Currently, this kills the tooltip tests.
+            ScratchpadAutosuggest.enableLiveCompletion(this.enabled);
             if (this.currentTooltip && this.currentTooltip.$el) {
                 this.currentTooltip.$el.hide();
                 this.currentTooltip = undefined;
             }
         }.bind(this);
 
-        this.editor.on("requestTooltip", this.requestTooltipDefaultCallback);   
+        // Sets the live completion status to whatever value is passed in.
+        this.setEnabledStatus = function(status) {
+            this.enabled = status;
+        }.bind(this);
+
+        this.editor.on("requestTooltip", this.requestTooltipDefaultCallback);
     },
 
     remove: function() {
@@ -107,7 +117,7 @@ window.TooltipEngine = Backbone.View.extend({
         _.each(this.tooltips, function(tooltip) {
             tooltip.remove();
         });
-        
+
         this.editor.off("requestTooltip", this.requestTooltipDefaultCallback);
     },
 
@@ -141,7 +151,7 @@ window.TooltipEngine = Backbone.View.extend({
         this.last = params;
 
         this.editor._emit("requestTooltip", params);
-    }, 
+    },
 
     // Returns true if we're inside a comment
     // This isn't a perfect check, but it is close enough.
@@ -159,23 +169,23 @@ TooltipEngine.classes = {};
   * Every Tooltip has the following major parts:
   * - initialize(), just accepts options and then tries to attach
   *   the html for the tooltip by callin render() and bind() as required
-  * 
+  *
   * - render() and bind() to set up the HTML
-  * 
-  * - A detector function. The detector functions are all bound to the 
-  *   requestTooltip event in their respective bind() method. They receive an event with 
-  *   information about where the cursor is and whether it got there because of a click, 
-  *   selection character added, etc. It chooses to either load its tooltip or let the 
+  *
+  * - A detector function. The detector functions are all bound to the
+  *   requestTooltip event in their respective bind() method. They receive an event with
+  *   information about where the cursor is and whether it got there because of a click,
+  *   selection character added, etc. It chooses to either load its tooltip or let the
   *   event keep bubbling
   *   > The detector function also sets aceLocation, which saves what portion of the
   *     text the selector is active for.
-  *   
-  * - updateText replaces whatever text is specified by the aceLocation 
+  *
+  * - updateText replaces whatever text is specified by the aceLocation
   *   with the new text. It is common for tooltips to override this function
-  *   so that they can accept a value in a different format, make it into a string 
+  *   so that they can accept a value in a different format, make it into a string
   *   and then pass the formatted value back to the function defined in TooltipBase
   *   to do the actual replace
-  * 
+  *
   * - placeOnScreen which determines where the HTML needs to be moved to in order
   *   for it to show up on by the cursor. This also pulls information from aceLocation
   *

--- a/js/ui/tooltip-engine.js
+++ b/js/ui/tooltip-engine.js
@@ -124,8 +124,6 @@ window.TooltipEngine = Backbone.View.extend({
             return;
         }
 
-        console.log(window.localStorage["autosuggest"]);
-
         this.last = this.last || {};
 
         var selection = this.editor.selection;

--- a/js/ui/tooltip-engine.js
+++ b/js/ui/tooltip-engine.js
@@ -93,9 +93,7 @@ window.TooltipEngine = Backbone.View.extend({
 
 
         this.requestTooltipDefaultCallback = function() {  //Fallback to hiding
-            // TODO (@GigabyteGiant) perhaps figure out a better way to do this?
-            // Currently, this kills the tooltip tests.
-            ScratchpadAutosuggest.enableLiveCompletion(this.enabled);
+            ScratchpadAutosuggest.enableLiveCompletion(this.enabled === "true");
             if (this.currentTooltip && this.currentTooltip.$el) {
                 this.currentTooltip.$el.hide();
                 this.currentTooltip = undefined;
@@ -125,6 +123,9 @@ window.TooltipEngine = Backbone.View.extend({
         if (this.ignore) {
             return;
         }
+
+        console.log(window.localStorage["autosuggest"]);
+
         this.last = this.last || {};
 
         var selection = this.editor.selection;

--- a/js/ui/tooltip-engine.js
+++ b/js/ui/tooltip-engine.js
@@ -2,7 +2,7 @@ window.TooltipEngine = Backbone.View.extend({
     initialize: function(options) {
         this.options = options;
         this.editor = options.editor;
-        this.enabled = (window.localStorage['autosuggest'] || true);
+        this.enabled = "true";
         var record = this.options.record;
 
         this.tooltips = {};

--- a/js/ui/tooltip-engine.js
+++ b/js/ui/tooltip-engine.js
@@ -2,7 +2,7 @@ window.TooltipEngine = Backbone.View.extend({
     initialize: function(options) {
         this.options = options;
         this.editor = options.editor;
-        this.enabled = options.enabled;
+        this.enabled = (window.localStorage['autosuggest']);
         var record = this.options.record;
 
         this.tooltips = {};


### PR DESCRIPTION
Similar to what was suggested by @pamelafox on the https://github.com/Khan/live-editor/issues/311 thread.

The keyboard shortcut is `Ctrl+Alt+A`/`Command+Option+A`.
*The keyboard shortcut is not added to the editor unless `autosuggestToggle=yes` is found in the URL*

I have yet to implement a menu, instead, this is a simple toggle.

A couple notes:
 • I did not include the new[er] files from the /build directory
 • I did **not** write any tests for this, as I didn't really feel it was necessary for a change like this (however, I can write one if needed).

Todo List:
 - [x] Figure out why AutoSuggest isn't using the value loaded from localStorage.

**Update**:
I won't be implementing a settings menu in this PR, as I have yet to figure out *how* I'm going to implement one. I will continue to work on a settings menu, and open another PR at a later time.
This PR is ready to be merged.