### PR TITLE
Minor Updates

### DIFF
--- a/demos/jquerysf/index.html
+++ b/demos/jquerysf/index.html
@@ -81,11 +81,22 @@ var nextButton = $('<button class="pure-button pure-button-primary">Next →</bu
     })
     .appendTo('.scratchpad-editor-wrap .scratchpad-toolbar');
 
+var paused = false;
+
 var pauseButton = $('<button class="pure-button pure-button-secondary">Pause ||</button>')
     .css('float', 'right')
     .css('margin-right', '10px')
     .on('click', function() {
-       window.clearTimeout(loadTimer);
+       paused = !paused;
+       
+       if (paused) {
+           $(this).html('Paused');
+           window.clearTimeout(loadTimer);
+       }
+       else {
+           $(this).html('Pause ||');
+           nextProgram();
+       }
     })
     .appendTo('.scratchpad-editor-wrap .scratchpad-toolbar');
 

--- a/demos/jquerysf/index.html
+++ b/demos/jquerysf/index.html
@@ -76,6 +76,7 @@ function nextProgram() {
 var nextButton = $('<button class="pure-button pure-button-primary">Next →</button>')
     .css('float', 'right')
     .on('click', function() {
+        window.clearTimeout(loadTimer);
         nextProgram();
     })
     .appendTo('.scratchpad-editor-wrap .scratchpad-toolbar');

--- a/demos/jquerysf/index.html
+++ b/demos/jquerysf/index.html
@@ -99,6 +99,14 @@ var prevButton = $('<button class="pure-button pure-button-primary">Prev ←</bu
 
 };
 
+var startTimer = function () {
+    loadTimer = window.setTimeout(function() {
+      slideNum++;
+      window.location.hash = slideNum;
+      loadProgram(slideNum);
+    }, 1000*30);
+}
+
 
 var loadProgram = function(num) {
     if (window.liveEditor) {
@@ -114,11 +122,7 @@ var loadProgram = function(num) {
          $('#program-title').text(title);
          $('#program-byline').text('By ' + username);
          makeEditor(code);
-         loadTimer = window.setTimeout(function() {
-           slideNum++;
-           window.location.hash = slideNum;
-           loadProgram(slideNum);
-         }, 1000*30);
+         startTimer();
      },
      error: function(xhr, status, e) {
       console.log(arguments);  


### PR DESCRIPTION
* clicking next() will reset the timer to avoid adding multiple calls
* abstracted startTimer() out of loadProgram() to allow it to be ran elsewhere
    * This was part of a first pass on extended pause and could be left out of this merge
* extend pause to have visual feedback and alias to "next" when unpaused