### PR TITLE
resolve conflict between handlebars and gulp-handlebars (#321)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,7 +22,7 @@ gulp.task("templates", function() {
     gulp.src(paths.templates)
         .pipe(changed("build/tmpl", {extension: ".js"}))
         .pipe(handlebars({
-            handlebars: require("handlebars")
+            handlebars: require("gulp-handlebars")
         }))
         .pipe(defineModule("plain"))
         .pipe(declare({


### PR DESCRIPTION
This fixed https://github.com/Khan/live-editor/issues/321 for me

I was getting an issue with ``this.merge is not a function``, as currently mentioned in the readme, but that solution of ``rm -rf node_modules/gulp-handlebars/node_modules/handlebars`` was not resolving the issue.