### PR TITLE
Throw a warning when writing code with invalid urls

### DIFF
--- a/build/js/live-editor.output_webpage.js
+++ b/build/js/live-editor.output_webpage.js
@@ -717,6 +717,7 @@ window.WebpageOutput = Backbone.View.extend({
             EVENT_HANDLER_ATTR_NOT_ALLOWED: $._("Sorry, but security restrictions on this site prevent you from using the \"%(attribute_name_value)s\" JavaScript event handler attribute.", error),
             HTML_CODE_IN_CSS_BLOCK: $._("Did you put HTML code inside a CSS area?", error),
             HTTP_LINK_FROM_HTTPS_PAGE: $._("The \"&lt;%(openTag_name)s&gt;\" tag's \"%(attribute_name_value)s\" attribute currently points to an insecure resource.", error),
+            WWW_LINK_WITHOUT_PROTOCOL: $._("The \"&lt;%(openTag_name)s&gt;\" tag's \"%(attribute_name_value)s\" attribute has an incomplete or missing protocol (http:// or https://).", error),
             INVALID_ATTR_NAME: $._("The attribute name \"%(attribute_name_value)s\" is not permitted under HTML5 naming conventions.", error),
             UNSUPPORTED_ATTR_NAMESPACE: $._("The attribute \"%(attribute_name_value)s\" uses an attribute namespace that is not permitted under HTML5 conventions.", error),
             MULTIPLE_ATTR_NAMESPACES: $._("The attribute \"%(attribute_name_value)s\" has multiple namespaces. Check your text and make sure there's only a single namespace prefix for the attribute.", error),

--- a/build/js/live-editor.output_webpage.js
+++ b/build/js/live-editor.output_webpage.js
@@ -717,7 +717,7 @@ window.WebpageOutput = Backbone.View.extend({
             EVENT_HANDLER_ATTR_NOT_ALLOWED: $._("Sorry, but security restrictions on this site prevent you from using the \"%(attribute_name_value)s\" JavaScript event handler attribute.", error),
             HTML_CODE_IN_CSS_BLOCK: $._("Did you put HTML code inside a CSS area?", error),
             HTTP_LINK_FROM_HTTPS_PAGE: $._("The \"&lt;%(openTag_name)s&gt;\" tag's \"%(attribute_name_value)s\" attribute currently points to an insecure resource.", error),
-            WWW_LINK_WITHOUT_PROTOCOL: $._("The \"&lt;%(openTag_name)s&gt;\" tag's \"%(attribute_name_value)s\" attribute has an incomplete or missing protocol (http:// or https://).", error),
+            LINK_WITHOUT_PROTOCOL: $._("The \"&lt;%(openTag_name)s&gt;\" tag's \"%(attribute_name_value)s\" attribute has an incomplete or missing protocol (http:// or https://).", error),
             INVALID_ATTR_NAME: $._("The attribute name \"%(attribute_name_value)s\" is not permitted under HTML5 naming conventions.", error),
             UNSUPPORTED_ATTR_NAMESPACE: $._("The attribute \"%(attribute_name_value)s\" uses an attribute namespace that is not permitted under HTML5 conventions.", error),
             MULTIPLE_ATTR_NAMESPACES: $._("The attribute \"%(attribute_name_value)s\" has multiple namespaces. Check your text and make sure there's only a single namespace prefix for the attribute.", error),

--- a/build/js/live-editor.output_webpage.js
+++ b/build/js/live-editor.output_webpage.js
@@ -717,7 +717,7 @@ window.WebpageOutput = Backbone.View.extend({
             EVENT_HANDLER_ATTR_NOT_ALLOWED: $._("Sorry, but security restrictions on this site prevent you from using the \"%(attribute_name_value)s\" JavaScript event handler attribute.", error),
             HTML_CODE_IN_CSS_BLOCK: $._("Did you put HTML code inside a CSS area?", error),
             HTTP_LINK_FROM_HTTPS_PAGE: $._("The \"&lt;%(openTag_name)s&gt;\" tag's \"%(attribute_name_value)s\" attribute currently points to an insecure resource.", error),
-            LINK_WITHOUT_PROTOCOL: $._("The \"&lt;%(openTag_name)s&gt;\" tag's \"%(attribute_name_value)s\" attribute has an incomplete or missing protocol (http:// or https://).", error),
+            INVALID_URL: $._("The \"&lt;%(openTag_name)s&gt;\" tag's \"%(attribute_name_value)s\" attribute has an incomplete or missing protocol (http:// or https://).", error),
             INVALID_ATTR_NAME: $._("The attribute name \"%(attribute_name_value)s\" is not permitted under HTML5 naming conventions.", error),
             UNSUPPORTED_ATTR_NAMESPACE: $._("The attribute \"%(attribute_name_value)s\" uses an attribute namespace that is not permitted under HTML5 conventions.", error),
             MULTIPLE_ATTR_NAMESPACES: $._("The attribute \"%(attribute_name_value)s\" has multiple namespaces. Check your text and make sure there's only a single namespace prefix for the attribute.", error),

--- a/build/js/live-editor.output_webpage_deps.js
+++ b/build/js/live-editor.output_webpage_deps.js
@@ -10009,6 +10009,29 @@ require("/tools/entry-point.js");
         cursor: attribute.value.start
       };
     },
+    //Special error type for links that start with www
+    WWW_LINK_WITHOUT_PROTOCOL: function(parser, nameTok, valueTok) {
+      var currentNode = parser.domBuilder.currentNode,
+          openTag = this._combine({
+            name: currentNode.nodeName.toLowerCase()
+          }, currentNode.parseInfo.openTag),
+          attribute = {
+            name: {
+              value: nameTok.value,
+              start: nameTok.interval.start,
+              end: nameTok.interval.end
+            },
+            value: {
+              start: valueTok.interval.start + 1,
+              end: valueTok.interval.end - 1
+            }
+          };
+      return {
+        openTag: openTag,
+        attribute: attribute,
+        cursor: attribute.value.start
+      };
+    },
     // These are CSS errors.
     UNKOWN_CSS_KEYWORD: function(parser, start, end, value) {
       return {
@@ -11315,6 +11338,11 @@ require("/tools/entry-point.js");
           );
         }
 
+        //Add a new validator to check if there is link content that is missing a protocol
+        if (valueTok.value.match(/www/) && !valueTok.value.match(/https?:\/\//)) {
+            throw new ParseError("WWW_LINK_WITHOUT_PROTOCOL", this, nameTok, valueTok);
+        }
+
         var unquotedValue = replaceEntityRefs(valueTok.value.slice(1, -1));
 
         if (this.options.noScript && /^javascript:/i.test(unquotedValue)) {
@@ -11344,17 +11372,17 @@ require("/tools/entry-point.js");
   //
   // The DOM builder is given a single document DOM object that will
   // be used to create all necessary DOM nodes.
-  function DOMBuilder(sourceCode, disallowActiveAttributes, scriptPreprocessor) { 
-    this.disallowActiveAttributes = disallowActiveAttributes; 
-    this.scriptPreprocessor = scriptPreprocessor; 
+  function DOMBuilder(sourceCode, disallowActiveAttributes, scriptPreprocessor) {
+    this.disallowActiveAttributes = disallowActiveAttributes;
+    this.scriptPreprocessor = scriptPreprocessor;
     this.document = document;
-    this.sourceCode = sourceCode; 
-    this.code = ""; 
+    this.sourceCode = sourceCode;
+    this.code = "";
     this.fragment = document.createDocumentFragment();
     this.currentNode = this.fragment;
     this.contexts = [];
     this.rules = [];
-    this.last = 0; 
+    this.last = 0;
     this.pushContext("html", 0);
   }
 
@@ -11407,44 +11435,44 @@ require("/tools/entry-point.js");
     },
     // This method appends a text node to the currently active element.
     text: function(text, parseInfo) {
-      if (this.currentNode && this.currentNode.attributes) { 
+      if (this.currentNode && this.currentNode.attributes) {
         var type = this.currentNode.attributes.type || "";
         if (type.toLowerCase) {
             type = type.toLowerCase();
         } else if (type.nodeValue) { // button type="submit"
             type = type.nodeValue;
         }
-        if (this.currentNode.nodeName.toLowerCase() === "script" && (!type || type === "text/javascript")) { 
-          this.javascript(text, parseInfo); 
+        if (this.currentNode.nodeName.toLowerCase() === "script" && (!type || type === "text/javascript")) {
+          this.javascript(text, parseInfo);
           // Don't actually add javascript to the DOM we're building
           // because it will execute and we don't want that.
           return;
         } else if (this.currentNode.nodeName.toLowerCase() === "style") {
           this.rules.push.apply(this.rules, parseInfo.rules);
-        } 
-      } 
+        }
+      }
       var textNode = this.document.createTextNode(text);
       textNode.parseInfo = parseInfo;
       this.currentNode.appendChild(textNode);
     },
-    javascript: function(text, parseInfo) { 
-      try { 
-        text = this.scriptPreprocessor(text); 
-      } catch(err) { 
-        // This is meant to handle esprima errors 
-        if (err.index && err.description && err.message) { 
-          var cursor = this.currentNode.parseInfo.openTag.end + err.index; 
-          throw {parseInfo: {type: "JAVASCRIPT_ERROR", message: err.description, cursor: cursor} }; 
-        } else { 
-          throw err; 
-        } 
-      } 
-      this.code += this.sourceCode.slice(this.last, parseInfo.start); 
-      this.code += text; 
-      this.last = parseInfo.end; 
+    javascript: function(text, parseInfo) {
+      try {
+        text = this.scriptPreprocessor(text);
+      } catch(err) {
+        // This is meant to handle esprima errors
+        if (err.index && err.description && err.message) {
+          var cursor = this.currentNode.parseInfo.openTag.end + err.index;
+          throw {parseInfo: {type: "JAVASCRIPT_ERROR", message: err.description, cursor: cursor} };
+        } else {
+          throw err;
+        }
+      }
+      this.code += this.sourceCode.slice(this.last, parseInfo.start);
+      this.code += text;
+      this.last = parseInfo.end;
     },
     close: function() {
-      this.code += this.sourceCode.slice(this.last); 
+      this.code += this.sourceCode.slice(this.last);
     }
   };
 
@@ -11495,9 +11523,9 @@ require("/tools/entry-point.js");
           errorDetectors = options.errorDetectors || [],
           disallowActiveAttributes = (typeof options.disallowActiveAttributes === "undefined") ? false : options.disallowActiveAttributes;
 
-      var scriptPreprocessor = options.scriptPreprocessor || function(x) {return x;}; 
-      var domBuilder = new DOMBuilder(html, disallowActiveAttributes, scriptPreprocessor); 
-      var parser = new HTMLParser(stream, domBuilder, options); 
+      var scriptPreprocessor = options.scriptPreprocessor || function(x) {return x;};
+      var domBuilder = new DOMBuilder(html, disallowActiveAttributes, scriptPreprocessor);
+      var parser = new HTMLParser(stream, domBuilder, options);
 
       try {
         var _ = parser.parse();

--- a/build/js/live-editor.output_webpage_deps.js
+++ b/build/js/live-editor.output_webpage_deps.js
@@ -10010,7 +10010,7 @@ require("/tools/entry-point.js");
       };
     },
     //Special error type for links that start with www
-    LINK_WITHOUT_PROTOCOL: function(parser, nameTok, valueTok) {
+    INVALID_URL: function(parser, nameTok, valueTok) {
       var currentNode = parser.domBuilder.currentNode,
           openTag = this._combine({
             name: currentNode.nodeName.toLowerCase()
@@ -11340,7 +11340,7 @@ require("/tools/entry-point.js");
 
         //Add a new validator to check if there is link content that is missing a protocol
         if ((nameTok.value === "href" || nameTok.value === "src") && !valueTok.value.match(/https?:\/\//)) {
-            throw new ParseError("LINK_WITHOUT_PROTOCOL", this, nameTok, valueTok);
+            throw new ParseError("INVALID_URL", this, nameTok, valueTok);
         }
 
         var unquotedValue = replaceEntityRefs(valueTok.value.slice(1, -1));

--- a/build/js/live-editor.output_webpage_deps.js
+++ b/build/js/live-editor.output_webpage_deps.js
@@ -10010,7 +10010,7 @@ require("/tools/entry-point.js");
       };
     },
     //Special error type for links that start with www
-    WWW_LINK_WITHOUT_PROTOCOL: function(parser, nameTok, valueTok) {
+    LINK_WITHOUT_PROTOCOL: function(parser, nameTok, valueTok) {
       var currentNode = parser.domBuilder.currentNode,
           openTag = this._combine({
             name: currentNode.nodeName.toLowerCase()
@@ -11339,8 +11339,8 @@ require("/tools/entry-point.js");
         }
 
         //Add a new validator to check if there is link content that is missing a protocol
-        if (valueTok.value.match(/www/) && !valueTok.value.match(/https?:\/\//)) {
-            throw new ParseError("WWW_LINK_WITHOUT_PROTOCOL", this, nameTok, valueTok);
+        if ((nameTok.value === "href" || nameTok.value === "src") && !valueTok.value.match(/https?:\/\//)) {
+            throw new ParseError("LINK_WITHOUT_PROTOCOL", this, nameTok, valueTok);
         }
 
         var unquotedValue = replaceEntityRefs(valueTok.value.slice(1, -1));

--- a/external/slowparse/slowparse.js
+++ b/external/slowparse/slowparse.js
@@ -422,7 +422,7 @@
       };
     },
     //Special error type for links that start with www
-    WWW_LINK_WITHOUT_PROTOCOL: function(parser, nameTok, valueTok) {
+    LINK_WITHOUT_PROTOCOL: function(parser, nameTok, valueTok) {
       var currentNode = parser.domBuilder.currentNode,
           openTag = this._combine({
             name: currentNode.nodeName.toLowerCase()
@@ -1751,8 +1751,8 @@
         }
 
         //Add a new validator to check if there is link content that is missing a protocol
-        if (valueTok.value.match(/www/) && !valueTok.value.match(/https?:\/\//)) {
-            throw new ParseError("WWW_LINK_WITHOUT_PROTOCOL", this, nameTok, valueTok);
+        if ((nameTok.value === "href" || nameTok.value === "src") && !valueTok.value.match(/https?:\/\//)) {
+            throw new ParseError("LINK_WITHOUT_PROTOCOL", this, nameTok, valueTok);
         }
 
         var unquotedValue = replaceEntityRefs(valueTok.value.slice(1, -1));

--- a/external/slowparse/slowparse.js
+++ b/external/slowparse/slowparse.js
@@ -421,8 +421,8 @@
         cursor: attribute.value.start
       };
     },
-    //Special error type for links that start with www
-    LINK_WITHOUT_PROTOCOL: function(parser, nameTok, valueTok) {
+    //Special error type for urls that start with www
+    INVALID_URL: function(parser, nameTok, valueTok) {
       var currentNode = parser.domBuilder.currentNode,
           openTag = this._combine({
             name: currentNode.nodeName.toLowerCase()
@@ -1750,9 +1750,13 @@
           );
         }
 
-        //Add a new validator to check if there is link content that is missing a protocol
-        if ((nameTok.value === "href" || nameTok.value === "src") && !valueTok.value.match(/https?:\/\//)) {
-            throw new ParseError("LINK_WITHOUT_PROTOCOL", this, nameTok, valueTok);
+        //Add a new validator to check if there is invalid link content
+        if (nameTok.value === "href" || nameTok.value === "src") {
+          if (!valueTok.match(regexp)) {
+            //Cheers to Diego Perini: https://gist.github.com/dperini/729294
+            var regexp = /^(?:(?:https?|ftp):\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,}))\.?)(?::\d{2,5})?(?:[/?#]\S*)?$/i;
+            throw new ParseError("INVALID_URL", this, nameTok, valueTok);
+          }
         }
 
         var unquotedValue = replaceEntityRefs(valueTok.value.slice(1, -1));

--- a/js/output/webpage/webpage-output.js
+++ b/js/output/webpage/webpage-output.js
@@ -173,7 +173,7 @@ window.WebpageOutput = Backbone.View.extend({
             EVENT_HANDLER_ATTR_NOT_ALLOWED: $._("Sorry, but security restrictions on this site prevent you from using the \"%(attribute_name_value)s\" JavaScript event handler attribute.", error),
             HTML_CODE_IN_CSS_BLOCK: $._("Did you put HTML code inside a CSS area?", error),
             HTTP_LINK_FROM_HTTPS_PAGE: $._("The \"&lt;%(openTag_name)s&gt;\" tag's \"%(attribute_name_value)s\" attribute currently points to an insecure resource.", error),
-            LINK_WITHOUT_PROTOCOL: $._("The \"&lt;%(openTag_name)s&gt;\" tag's \"%(attribute_name_value)s\" attribute has an incomplete or missing protocol (http:// or https://).", error),
+            INVALID_URL: $._("The \"&lt;%(openTag_name)s&gt;\" tag's \"%(attribute_name_value)s\" attribute points to an invalid URL.  Did you include the protocol (http:// or https://)?", error),
             INVALID_ATTR_NAME: $._("The attribute name \"%(attribute_name_value)s\" is not permitted under HTML5 naming conventions.", error),
             UNSUPPORTED_ATTR_NAMESPACE: $._("The attribute \"%(attribute_name_value)s\" uses an attribute namespace that is not permitted under HTML5 conventions.", error),
             MULTIPLE_ATTR_NAMESPACES: $._("The attribute \"%(attribute_name_value)s\" has multiple namespaces. Check your text and make sure there's only a single namespace prefix for the attribute.", error),

--- a/js/output/webpage/webpage-output.js
+++ b/js/output/webpage/webpage-output.js
@@ -173,7 +173,7 @@ window.WebpageOutput = Backbone.View.extend({
             EVENT_HANDLER_ATTR_NOT_ALLOWED: $._("Sorry, but security restrictions on this site prevent you from using the \"%(attribute_name_value)s\" JavaScript event handler attribute.", error),
             HTML_CODE_IN_CSS_BLOCK: $._("Did you put HTML code inside a CSS area?", error),
             HTTP_LINK_FROM_HTTPS_PAGE: $._("The \"&lt;%(openTag_name)s&gt;\" tag's \"%(attribute_name_value)s\" attribute currently points to an insecure resource.", error),
-            WWW_LINK_WITHOUT_PROTOCOL: $._("The \"&lt;%(openTag_name)s&gt;\" tag's \"%(attribute_name_value)s\" attribute has an incomplete or missing protocol (http:// or https://).", error),
+            LINK_WITHOUT_PROTOCOL: $._("The \"&lt;%(openTag_name)s&gt;\" tag's \"%(attribute_name_value)s\" attribute has an incomplete or missing protocol (http:// or https://).", error),
             INVALID_ATTR_NAME: $._("The attribute name \"%(attribute_name_value)s\" is not permitted under HTML5 naming conventions.", error),
             UNSUPPORTED_ATTR_NAMESPACE: $._("The attribute \"%(attribute_name_value)s\" uses an attribute namespace that is not permitted under HTML5 conventions.", error),
             MULTIPLE_ATTR_NAMESPACES: $._("The attribute \"%(attribute_name_value)s\" has multiple namespaces. Check your text and make sure there's only a single namespace prefix for the attribute.", error),

--- a/js/output/webpage/webpage-output.js
+++ b/js/output/webpage/webpage-output.js
@@ -24,12 +24,12 @@ window.WebpageOutput = Backbone.View.extend({
 
         // Set up infinite loop protection
         this.loopProtector = new LoopProtector(this.infiniteLoopCallback.bind(this));
-        this.$frame.contentWindow.KAInfiniteLoopProtect = 
+        this.$frame.contentWindow.KAInfiniteLoopProtect =
             this.loopProtector.KAInfiniteLoopProtect;
         // In case frame didn't load (like in IE10), this adds it
         //  once the frame has loaded
         this.$frame.addEventListener("load", function () {
-            this.$frame.contentWindow.KAInfiniteLoopProtect = 
+            this.$frame.contentWindow.KAInfiniteLoopProtect =
                 this.loopProtector.KAInfiniteLoopProtect;
         }.bind(this));
         // Do this at the end so variables I add to the global scope stay
@@ -99,7 +99,7 @@ window.WebpageOutput = Backbone.View.extend({
             deferred.resolve([]);
             return deferred;
         }
-        
+
         this.userCode = userCode;
         userCode = userCode || "";
 
@@ -173,6 +173,7 @@ window.WebpageOutput = Backbone.View.extend({
             EVENT_HANDLER_ATTR_NOT_ALLOWED: $._("Sorry, but security restrictions on this site prevent you from using the \"%(attribute_name_value)s\" JavaScript event handler attribute.", error),
             HTML_CODE_IN_CSS_BLOCK: $._("Did you put HTML code inside a CSS area?", error),
             HTTP_LINK_FROM_HTTPS_PAGE: $._("The \"&lt;%(openTag_name)s&gt;\" tag's \"%(attribute_name_value)s\" attribute currently points to an insecure resource.", error),
+            WWW_LINK_WITHOUT_PROTOCOL: $._("The \"&lt;%(openTag_name)s&gt;\" tag's \"%(attribute_name_value)s\" attribute has an incomplete or missing protocol (http:// or https://).", error),
             INVALID_ATTR_NAME: $._("The attribute name \"%(attribute_name_value)s\" is not permitted under HTML5 naming conventions.", error),
             UNSUPPORTED_ATTR_NAMESPACE: $._("The attribute \"%(attribute_name_value)s\" uses an attribute namespace that is not permitted under HTML5 conventions.", error),
             MULTIPLE_ATTR_NAMESPACES: $._("The attribute \"%(attribute_name_value)s\" has multiple namespaces. Check your text and make sure there's only a single namespace prefix for the attribute.", error),
@@ -308,7 +309,7 @@ window.WebpageOutput = Backbone.View.extend({
         this.foundRunTimeError = false;
         this.frameDoc.open();
         // It's necessary in FF/IE to redefine it here
-        this.$frame.contentWindow.KAInfiniteLoopProtect = 
+        this.$frame.contentWindow.KAInfiniteLoopProtect =
                 this.loopProtector.KAInfiniteLoopProtect;
         this.$frame.contentWindow.addEventListener("error", function () {
             this.foundRunTimeError = true;
@@ -324,7 +325,7 @@ window.WebpageOutput = Backbone.View.extend({
         } else {
             callback([]);
         }
-        
+
     },
 
     clear: function() {
@@ -337,4 +338,3 @@ window.WebpageOutput = Backbone.View.extend({
 });
 
 LiveEditorOutput.registerOutput("webpage", WebpageOutput);
-

--- a/tests/output/webpage/output_test.js
+++ b/tests/output/webpage/output_test.js
@@ -177,19 +177,19 @@ describe("Linting", function() {
 
     failingTest("Malformed outward link href without protocol banned",
         "<a href='www.google.com'></a>", [
-            {row: 0, column: 9, lint: {type: "LINK_WITHOUT_PROTOCOL"}}
+            {row: 0, column: 9, lint: {type: "INVALID_URL"}}
         ]
     );
 
     failingTest("Malformed outward link href without protocol banned",
         "<a href='google.com'></a>", [
-            {row: 0, column: 9, lint: {type: "LINK_WITHOUT_PROTOCOL"}}
+            {row: 0, column: 9, lint: {type: "INVALID_URL"}}
         ]
     );
 
     failingTest("Malformed outward script without protocol banned",
         "<script src='www.google.com'></script>", [
-            {row: 0, column: 13, lint: {type: "LINK_WITHOUT_PROTOCOL"}}
+            {row: 0, column: 13, lint: {type: "INVALID_URL"}}
         ]
     );
 

--- a/tests/output/webpage/output_test.js
+++ b/tests/output/webpage/output_test.js
@@ -177,13 +177,19 @@ describe("Linting", function() {
 
     failingTest("Malformed outward link href without protocol banned",
         "<a href='www.google.com'></a>", [
-            {row: 0, column: 9, lint: {type: "WWW_LINK_WITHOUT_PROTOCOL"}}
+            {row: 0, column: 9, lint: {type: "LINK_WITHOUT_PROTOCOL"}}
+        ]
+    );
+
+    failingTest("Malformed outward link href without protocol banned",
+        "<a href='google.com'></a>", [
+            {row: 0, column: 9, lint: {type: "LINK_WITHOUT_PROTOCOL"}}
         ]
     );
 
     failingTest("Malformed outward script without protocol banned",
         "<script src='www.google.com'></script>", [
-            {row: 0, column: 13, lint: {type: "WWW_LINK_WITHOUT_PROTOCOL"}}
+            {row: 0, column: 13, lint: {type: "LINK_WITHOUT_PROTOCOL"}}
         ]
     );
 

--- a/tests/output/webpage/output_test.js
+++ b/tests/output/webpage/output_test.js
@@ -122,6 +122,9 @@ describe("Linting", function() {
         '<button type="submit">Submit</button>'
     ]);
 
+    test("regular links are not banned", '<a href="http://google.com"></a>');
+    test("regular scripts are not banned", '<script src="http://google.com"></script>');
+
     failingTest("INVALID_TAG_NAME raised by < at EOF",
         '<', [
             {row: 0, column: 0, lint: {type: "INVALID_TAG_NAME"}}
@@ -172,6 +175,18 @@ describe("Linting", function() {
         ]
     );
 
+    failingTest("Malformed outward link href without protocol banned",
+        "<a href='www.google.com'></a>", [
+            {row: 0, column: 9, lint: {type: "WWW_LINK_WITHOUT_PROTOCOL"}}
+        ]
+    );
+
+    failingTest("Malformed outward script without protocol banned",
+        "<script src='www.google.com'></script>", [
+            {row: 0, column: 13, lint: {type: "WWW_LINK_WITHOUT_PROTOCOL"}}
+        ]
+    );
+
     if (!isFirefox()) {
         // An exception occurs in slowparse when parsing this HTML on
         // Chrome, Safari, and phantomjs.
@@ -199,10 +214,10 @@ describe("Linting", function() {
     failingTest("Infinite loop errors",
         "<script> while(true){} </script>", [
             // Infinite loops dont give a location for their error message
-            {row: undefined, column: undefined, text: 
+            {row: undefined, column: undefined, text:
                 '<span class="text">Your javascript is taking too long to run.' +
                 ' Perhaps you have a mistake in your code?</span>'},
-            {row: undefined, column: undefined, text: 
+            {row: undefined, column: undefined, text:
                 '<span class="text">Your javascript encountered a runtime error. ' +
                 ' Check your console for more information.</span>'}
         ]
@@ -211,7 +226,7 @@ describe("Linting", function() {
     failingTest("Runtime errors",
         "<script> bla(x);</script>", [
             // Infinite loops dont give a location for their error message
-            {row: undefined, column: undefined, text: 
+            {row: undefined, column: undefined, text:
                 'Your javascript encountered a runtime error. ' +
                 'Check your console for more information.'}
         ]


### PR DESCRIPTION
Deals with #306.  Technically, this only supports urls which are "invalid" because they are missing a protocol, and therefore not linking to the expected place.

I wanted to verify two things:
- I modified Slowparse for this to work &mdash; it felt like the least-obstructive way to do that.  Is this alright?  I was a little bothered because Slowparse is more of an HTML validator, and technically there is nothing invalid about links with missing protocols.
- I throw a `ParseError` when I find a problem.  I noticed that there was [code](https://github.com/jjwon/live-editor/blob/b5f9192567b64ecd3674013535db0fd8170ed11e/external/slowparse/slowparse.js#L1746) that added to some `warnings` array, but I couldn't figure out how this got used.

Also, a lot of trailing whitespaces got eaten by my editor, which is why so many lines are changed.

*Maybe To Do?*
- [ ] Add a new error when urls are actually invalid, and replace the invalid symbols by their corresponding percent-encodings (it seems that this is already handled by the link-redirector, though)