### PR TITLE
Resolved #395

### DIFF
--- a/build/js/live-editor.output_pjs_deps.js
+++ b/build/js/live-editor.output_pjs_deps.js
@@ -87613,7 +87613,12 @@ ASTTransforms.rewriteContextVariables = function (envName) {
                     // Single VariableDeclarators
 
                     var decl = node.declarations[0];
-                    if (decl.init === null) {
+
+                    // If the current variable declaration has an "init" value of null
+                    //  (IE. no init value given to parser), and the current node type
+                    //  doesn't match "ForInStatement" (a for-in loop), exit the
+                    //  function.
+                    if (decl.init === null && parent.type !== "ForInStatement") {
                         return;
                     }
 
@@ -87625,12 +87630,21 @@ ASTTransforms.rewriteContextVariables = function (envName) {
                         if (["Program", "BlockStatement"].includes(parent.type)) {
                             return b.ExpressionStatement(b.AssignmentExpression(b.MemberExpression(b.Identifier(envName), b.Identifier(decl.id.name)), "=", decl.init));
                         } else {
-                            // Handle variables declared inside a 'for' statement
-                            // occurring in the global scope.
-                            //
-                            // e.g. for (var i = 0; i < 10; i++) { ... } =>
-                            //      for (__env__.i = 0; __env__.i < 10; __env__.i++)
-                            return b.AssignmentExpression(b.MemberExpression(b.Identifier(envName), b.Identifier(decl.id.name)), "=", decl.init);
+                            if (["ForStatement"].includes(parent.type)) {
+                                // Handle variables declared inside a 'for' statement
+                                // occurring in the global scope.
+                                //
+                                // e.g. for (var i = 0; i < 10; i++) { ... } =>
+                                //      for (__env__.i = 0; __env__.i < 10; __env__.i++)
+                                return b.AssignmentExpression(b.MemberExpression(b.Identifier(envName), b.Identifier(decl.id.name)), "=", decl.init === null ? "a" : decl.init);
+                            } else if (["ForInStatement"].includes(parent.type)) {
+                                // Handle variables declared inside a 'for in' statement,
+                                //  occuring in the global scope.
+                                // Example:
+                                //  for (var i in obj) { ... }
+                                //  for (__env__.i in __env__.obj) { ... }
+                                return b.MemberExpression(b.Identifier(envName), b.Identifier(decl.id.name));
+                            }
                         }
                     }
                 } else {

--- a/build/js/live-editor.output_pjs_deps.js
+++ b/build/js/live-editor.output_pjs_deps.js
@@ -87636,7 +87636,7 @@ ASTTransforms.rewriteContextVariables = function (envName) {
                                 //
                                 // e.g. for (var i = 0; i < 10; i++) { ... } =>
                                 //      for (__env__.i = 0; __env__.i < 10; __env__.i++)
-                                return b.AssignmentExpression(b.MemberExpression(b.Identifier(envName), b.Identifier(decl.id.name)), "=", decl.init === null ? "a" : decl.init);
+                                return b.AssignmentExpression(b.MemberExpression(b.Identifier(envName), b.Identifier(decl.id.name)), "=", decl.init);
                             } else if (["ForInStatement"].includes(parent.type)) {
                                 // Handle variables declared inside a 'for in' statement,
                                 //  occuring in the global scope.

--- a/build/js/live-editor.output_webpage.js
+++ b/build/js/live-editor.output_webpage.js
@@ -717,7 +717,7 @@ window.WebpageOutput = Backbone.View.extend({
             EVENT_HANDLER_ATTR_NOT_ALLOWED: $._("Sorry, but security restrictions on this site prevent you from using the \"%(attribute_name_value)s\" JavaScript event handler attribute.", error),
             HTML_CODE_IN_CSS_BLOCK: $._("Did you put HTML code inside a CSS area?", error),
             HTTP_LINK_FROM_HTTPS_PAGE: $._("The \"&lt;%(openTag_name)s&gt;\" tag's \"%(attribute_name_value)s\" attribute currently points to an insecure resource.", error),
-            INVALID_URL: $._("The \"&lt;%(openTag_name)s&gt;\" tag's \"%(attribute_name_value)s\" attribute has an incomplete or missing protocol (http:// or https://).", error),
+            INVALID_URL: $._("The \"&lt;%(openTag_name)s&gt;\" tag's \"%(attribute_name_value)s\" attribute points to an invalid URL.  Did you include the protocol (http:// or https://)?", error),
             INVALID_ATTR_NAME: $._("The attribute name \"%(attribute_name_value)s\" is not permitted under HTML5 naming conventions.", error),
             UNSUPPORTED_ATTR_NAMESPACE: $._("The attribute \"%(attribute_name_value)s\" uses an attribute namespace that is not permitted under HTML5 conventions.", error),
             MULTIPLE_ATTR_NAMESPACES: $._("The attribute \"%(attribute_name_value)s\" has multiple namespaces. Check your text and make sure there's only a single namespace prefix for the attribute.", error),

--- a/build/js/live-editor.output_webpage_deps.js
+++ b/build/js/live-editor.output_webpage_deps.js
@@ -10009,7 +10009,7 @@ require("/tools/entry-point.js");
         cursor: attribute.value.start
       };
     },
-    //Special error type for links that start with www
+    //Special error type for urls that start with www
     INVALID_URL: function(parser, nameTok, valueTok) {
       var currentNode = parser.domBuilder.currentNode,
           openTag = this._combine({
@@ -11338,9 +11338,13 @@ require("/tools/entry-point.js");
           );
         }
 
-        //Add a new validator to check if there is link content that is missing a protocol
-        if ((nameTok.value === "href" || nameTok.value === "src") && !valueTok.value.match(/https?:\/\//)) {
+        //Add a new validator to check if there is invalid link content
+        if (nameTok.value === "href" || nameTok.value === "src") {
+          if (!valueTok.match(regexp)) {
+            //Cheers to Diego Perini: https://gist.github.com/dperini/729294
+            var regexp = /^(?:(?:https?|ftp):\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,}))\.?)(?::\d{2,5})?(?:[/?#]\S*)?$/i;
             throw new ParseError("INVALID_URL", this, nameTok, valueTok);
+          }
         }
 
         var unquotedValue = replaceEntityRefs(valueTok.value.slice(1, -1));

--- a/js/output/pjs/pjs-ast-transforms.js
+++ b/js/output/pjs/pjs-ast-transforms.js
@@ -132,7 +132,12 @@ ASTTransforms.rewriteContextVariables = function(envName) {
                     // Single VariableDeclarators
 
                     let decl = node.declarations[0];
-                    if (decl.init === null) {
+
+                    // If the current variable declaration has an "init" value of null
+                    //  (IE. no init value given to parser), and the current node type
+                    //  doesn't match "ForInStatement" (a for-in loop), exit the
+                    //  function.
+                    if (decl.init === null && parent.type !== "ForInStatement") {
                         return;
                     }
 
@@ -150,16 +155,25 @@ ASTTransforms.rewriteContextVariables = function(envName) {
                                 )
                             );
                         } else {
-                            // Handle variables declared inside a 'for' statement
-                            // occurring in the global scope.
-                            //
-                            // e.g. for (var i = 0; i < 10; i++) { ... } =>
-                            //      for (__env__.i = 0; __env__.i < 10; __env__.i++)
-                            return b.AssignmentExpression(
-                                b.MemberExpression(b.Identifier(envName),b.Identifier(decl.id.name)),
-                                "=",
-                                decl.init
-                            );
+                            if (["ForStatement"].includes(parent.type)) {
+                                // Handle variables declared inside a 'for' statement
+                                // occurring in the global scope.
+                                //
+                                // e.g. for (var i = 0; i < 10; i++) { ... } =>
+                                //      for (__env__.i = 0; __env__.i < 10; __env__.i++)
+                                return b.AssignmentExpression(
+                                    b.MemberExpression(b.Identifier(envName),b.Identifier(decl.id.name)),
+                                    "=",
+                                    decl.init === null ? "a" : decl.init
+                                );
+                            } else if (["ForInStatement"].includes(parent.type)) {
+                                // Handle variables declared inside a 'for in' statement,
+                                //  occuring in the global scope.
+                                // Example:
+                                //  for (var i in obj) { ... }
+                                //  for (__env__.i in __env__.obj) { ... }
+                                return b.MemberExpression(b.Identifier(envName), b.Identifier(decl.id.name))
+                            }
                         }
                     }
                 } else {
@@ -180,7 +194,6 @@ ASTTransforms.rewriteContextVariables = function(envName) {
                                         decl.init
                                     )
                                 ));
-
                         } else {
                             // Before: for (var i = 0, j = 0; i * j < 100; i++, j++) { ... }
                             // After: for (__env__.i = 0, __env__.j = 0; __env__.i * __env__.j < 100; ...) { ... }

--- a/js/output/pjs/pjs-ast-transforms.js
+++ b/js/output/pjs/pjs-ast-transforms.js
@@ -164,7 +164,7 @@ ASTTransforms.rewriteContextVariables = function(envName) {
                                 return b.AssignmentExpression(
                                     b.MemberExpression(b.Identifier(envName),b.Identifier(decl.id.name)),
                                     "=",
-                                    decl.init === null ? "a" : decl.init
+                                    decl.init
                                 );
                             } else if (["ForInStatement"].includes(parent.type)) {
                                 // Handle variables declared inside a 'for in' statement,

--- a/tests/output/pjs/ast_transform_tests.js
+++ b/tests/output/pjs/ast_transform_tests.js
@@ -144,4 +144,22 @@ describe("AST Transforms", function () {
 
         expect(transformedCode).to.equal(expectedCode);
     });
+
+    it("should handle variable declarations inside a 'for-in' statement", function () {
+        var transformedCode = transformCode(getCodeFromOptions(function() {
+            var obj = { a: 1, b: 2, c: 3 };
+            for (var i in obj) {
+                print(i);
+            }
+        }));
+
+        var expectedCode = cleanupCode(getCodeFromOptions(function() {
+            __env__.obj = { a: 1, b: 2, c: 3 };
+            for (__env__.i in __env__.obj) {
+                __env__.print(__env__.i);
+            }
+        }));
+
+        expect(transformedCode).to.equal(expectedCode);
+    });
 });

--- a/tests/output/pjs/ast_transform_tests.js
+++ b/tests/output/pjs/ast_transform_tests.js
@@ -125,7 +125,7 @@ describe("AST Transforms", function () {
 
         expect(transformedCode).to.equal(expectedCode);
     });
-    
+
     it("should handle draw loop functions inside 'draw'", function () {
         var transformedCode = transformCode(getCodeFromOptions(function() {
             var draw = function() {

--- a/tests/output/pjs/output_test.js
+++ b/tests/output/pjs/output_test.js
@@ -143,6 +143,13 @@ describe("Scratchpad Output Exec", function() {
         image(img, 0, 0);
     });
 
+    test("for-in loop with variable declaration", function() {
+        var obj = { a: 1, b: 2, c: 3 };
+        for (var i in obj) {
+            println(obj);
+        }
+    });
+
     failingTest("getImage with simple string", function () {
         var toolbox = getImage("toolbox");
 


### PR DESCRIPTION
This PR resolves https://github.com/Khan/live-editor/issues/395.

https://github.com/Khan/live-editor/issues/395 prevented `for-in` loops from functioning properly in the PJS environment (see issue for more information).

Important changes:
 * I added a second condition to the if that is located on line 140 of `js/output/pjs/pjs-ast-transform.js`. This second condition makes sure we don't exit the function, if the current node is a `ForInStatement`.
 * I added an if/else to the else clause located on line 157 of `js/output/pjs/pjs-ast-transform.js`. This allowed me to add a check to see if the current node type is a `ForInStatement`.

I added two "tests"; one in `tests/output/pjs/ast_transform_tests.js`, and one in `tests/output/pjs/output_test.js`.

To test that this works manually:
Visit `demos/simple` in your browser, and paste the following code:...
```
var obj = {
    a: 1,
    b: 2,
    c: 3
};

for (var i in obj) {
    println(i);
}
```
...you should see something like this, printed to the PJS console:
```
a
b
c
```

Gigabyte Giant (<brynden.bielefeld@hotmail.com>)