### PR TITLE
Fixed failing test

### DIFF
--- a/tests/output/pjs/ast_transform_tests.js
+++ b/tests/output/pjs/ast_transform_tests.js
@@ -147,14 +147,22 @@ describe("AST Transforms", function () {
 
     it("should handle variable declarations inside a 'for-in' statement", function () {
         var transformedCode = transformCode(getCodeFromOptions(function() {
-            var obj = { a: 1, b: 2, c: 3 };
+            var obj = {
+                a: 1,
+                b: 2,
+                c: 3
+            };
             for (var i in obj) {
                 print(i);
             }
         }));
 
         var expectedCode = cleanupCode(getCodeFromOptions(function() {
-            __env__.obj = { a: 1, b: 2, c: 3 };
+            __env__.obj = {
+                a: 1,
+                b: 2,
+                c: 3
+            };
             for (__env__.i in __env__.obj) {
                 __env__.print(__env__.i);
             }


### PR DESCRIPTION
...since the `expectedCode` was putting object properties on new lines, it was causing the test to fail.

I just put each object property on a new line, and the test seems to pass.