### PR TITLE
Display gutter warnings

### DIFF
--- a/build/js/live-editor.output_webpage.js
+++ b/build/js/live-editor.output_webpage.js
@@ -734,6 +734,8 @@ window.WebpageOutput = Backbone.View.extend({
         // Mostly borrowed from:
         // https://github.com/mozilla/thimble.webmaker.org/blob/master/locale/en_US/thimble-dialog-messages.json
         return ({
+            NO_DOCTYPE_FOUND: $._("A DOCTYPE declaration should be the first item on the page.", error),
+            HTML_NOT_ROOT_ELEMENT: $._("The root element on the page should be an <html> element.", error),
             ATTRIBUTE_IN_CLOSING_TAG: $._("A closing \"&lt;/%(closeTag_name)s&gt;\" tag cannot contain any attributes.", error),
             CLOSE_TAG_FOR_VOID_ELEMENT: $._("You have a closing \"&lt;/%(closeTag_name)s&gt;\" tag for a void element (and void elements don't need to be closed).", error),
             CSS_MIXED_ACTIVECONTENT: $._("You have a css property \"%(cssProperty_property)s\" with a \"url()\" value that currently points to an insecure resource.", error),
@@ -745,6 +747,7 @@ window.WebpageOutput = Backbone.View.extend({
             UNSUPPORTED_ATTR_NAMESPACE: $._("The attribute \"%(attribute_name_value)s\" uses an attribute namespace that is not permitted under HTML5 conventions.", error),
             MULTIPLE_ATTR_NAMESPACES: $._("The attribute \"%(attribute_name_value)s\" has multiple namespaces. Check your text and make sure there's only a single namespace prefix for the attribute.", error),
             INVALID_CSS_PROPERTY_NAME: $._("The CSS property \"%(cssProperty_property)s\" does not exist.", error),
+            IMPROPER_CSS_VALUE: $._("The CSS value \"%(cssValue_value)s\" is malformed.", error),
             INVALID_TAG_NAME: $._("A \"&lt;\" character appears to be the beginning of a tag, but is not followed by a valid tag name. If you want a \"&lt;\" to appear on your Web page, try using \"&amp;lt;\" instead. Otherwise, check your spelling.", error),
             JAVASCRIPT_URL_NOT_ALLOWED: $._("Sorry, but security restrictions on this site prevent you from using the \"javascript:\" URL.", error),
             MISMATCHED_CLOSE_TAG: $._("You have a closing \"&lt;/%(closeTag_name)s&gt;\" tag that doesn't pair with the opening \"&lt;%(openTag_name)s&gt;\" tag. This is likely due to a missing or misordered \"&lt;/%(openTag_name)s&gt;\" tag.", error),

--- a/build/js/live-editor.output_webpage_deps.js
+++ b/build/js/live-editor.output_webpage_deps.js
@@ -9755,6 +9755,17 @@ require("/tools/entry-point.js");
       return obj;
     },
     // These are HTML errors.
+    NO_DOCTYPE_FOUND: function() {},
+    HTML_NOT_ROOT_ELEMENT: function(parser) {
+      var currentNode = parser.domBuilder.currentNode.firstElementChild,
+          openTag = this._combine({
+            name: currentNode.nodeName.toLowerCase()
+          }, currentNode.parseInfo.openTag);
+      return {
+        openTag: openTag,
+        cursor: openTag.start
+      };
+    },
     UNCLOSED_TAG: function(parser) {
       var currentNode = parser.domBuilder.currentNode,
           openTag = this._combine({
@@ -10113,6 +10124,16 @@ require("/tools/entry-point.js");
       };
     },
     UNFINISHED_CSS_VALUE: function(parser, start, end, value) {
+      return {
+        cssValue: {
+          start: start,
+          end: end,
+          value: value
+        },
+        cursor: start
+      };
+    },
+    IMPROPER_CSS_VALUE: function(parser, start, end, value) {
       return {
         cssValue: {
           start: start,
@@ -10786,7 +10807,6 @@ require("/tools/entry-point.js");
       if(token === null) {
         throw new ParseError("MISSING_CSS_VALUE", this, propertyStart, propertyStart+property.length, property);
       }
-
       var next = (!this.stream.end() ? this.stream.next() : "end of stream"),
           errorMsg = "[_parseValue] Expected }, <, or ;, instead found "+next;
 
@@ -10797,6 +10817,17 @@ require("/tools/entry-point.js");
 
       if (value === '') {
         throw new ParseError("MISSING_CSS_VALUE", this, this.stream.pos-1, this.stream.pos);
+      }
+
+      // If value has a newline, the tokenizer ate the next pair, so we're missing a ;
+      if (value.indexOf('\n') > -1) {
+        value = value.substr(0, value.indexOf('\n'));
+        this.warnings.push(new ParseError("UNFINISHED_CSS_VALUE", this, valueStart, valueEnd, value));
+      }
+
+      // if value matches this regex, then there's a space between
+      if (value.match(/(#|rgb|rgba|hsl|hsla)\s+\(/)) {
+        this.warnings.push(new ParseError("IMPROPER_CSS_VALUE", this, valueStart, valueEnd, value));
       }
 
       // At this point we can fill in the *value* part of the current
@@ -10828,6 +10859,7 @@ require("/tools/entry-point.js");
       }
       else if (next === '}') {
         // This is block level termination; try to read a new selector.
+        this.warnings.push(new ParseError("UNFINISHED_CSS_VALUE", this, valueStart, valueEnd, value));
         this.currentRule.declarations.end = this.stream.pos;
         this._bindCurrentRule();
         this.stream.markTokenStartAfterSpace();
@@ -10999,13 +11031,16 @@ require("/tools/entry-point.js");
       // First we check to see if the beginning of our stream is
       // an HTML5 doctype tag. We're currently quite strict and don't
       // parse XHTML or other doctypes.
-      if (this.stream.match(this.html5Doctype, true, true))
+      if (this.stream.match(this.html5Doctype, true, true)) {
         this.domBuilder.fragment.parseInfo = {
           doctype: {
             start: 0,
             end: this.stream.pos
           }
         };
+      } else {
+        this.warnings.push(new ParseError("NO_DOCTYPE_FOUND"));
+      }
 
       // Next, we parse "tag soup", creating text nodes and diving into
       // tags as we find them.
@@ -11023,6 +11058,11 @@ require("/tools/entry-point.js");
       // we test for that.
       if (this.domBuilder.currentNode != this.domBuilder.fragment)
         throw new ParseError("UNCLOSED_TAG", this);
+
+      if (this.domBuilder.currentNode.children &&
+        (this.domBuilder.currentNode.children.length !== 1 || this.domBuilder.currentNode.firstElementChild.tagName !== "HTML")) {
+        this.warnings.push(new ParseError("HTML_NOT_ROOT_ELEMENT", this));
+      }
 
       return {
         warnings: (this.warnings.length > 0 ? this.warnings : false)

--- a/external/slowparse/slowparse.js
+++ b/external/slowparse/slowparse.js
@@ -167,6 +167,17 @@
       return obj;
     },
     // These are HTML errors.
+    NO_DOCTYPE_FOUND: function() {},
+    HTML_NOT_ROOT_ELEMENT: function(parser) {
+      var currentNode = parser.domBuilder.currentNode.firstElementChild,
+          openTag = this._combine({
+            name: currentNode.nodeName.toLowerCase()
+          }, currentNode.parseInfo.openTag);
+      return {
+        openTag: openTag,
+        cursor: openTag.start
+      };
+    },
     UNCLOSED_TAG: function(parser) {
       var currentNode = parser.domBuilder.currentNode,
           openTag = this._combine({
@@ -525,6 +536,16 @@
       };
     },
     UNFINISHED_CSS_VALUE: function(parser, start, end, value) {
+      return {
+        cssValue: {
+          start: start,
+          end: end,
+          value: value
+        },
+        cursor: start
+      };
+    },
+    IMPROPER_CSS_VALUE: function(parser, start, end, value) {
       return {
         cssValue: {
           start: start,
@@ -1198,7 +1219,6 @@
       if(token === null) {
         throw new ParseError("MISSING_CSS_VALUE", this, propertyStart, propertyStart+property.length, property);
       }
-
       var next = (!this.stream.end() ? this.stream.next() : "end of stream"),
           errorMsg = "[_parseValue] Expected }, <, or ;, instead found "+next;
 
@@ -1209,6 +1229,17 @@
 
       if (value === '') {
         throw new ParseError("MISSING_CSS_VALUE", this, this.stream.pos-1, this.stream.pos);
+      }
+
+      // If value has a newline, the tokenizer ate the next pair, so we're missing a ;
+      if (value.indexOf('\n') > -1) {
+        value = value.substr(0, value.indexOf('\n'));
+        this.warnings.push(new ParseError("UNFINISHED_CSS_VALUE", this, valueStart, valueEnd, value));
+      }
+
+      // if value matches this regex, then there's a space between
+      if (value.match(/(#|rgb|rgba|hsl|hsla)\s+\(/)) {
+        this.warnings.push(new ParseError("IMPROPER_CSS_VALUE", this, valueStart, valueEnd, value));
       }
 
       // At this point we can fill in the *value* part of the current
@@ -1240,6 +1271,7 @@
       }
       else if (next === '}') {
         // This is block level termination; try to read a new selector.
+        this.warnings.push(new ParseError("UNFINISHED_CSS_VALUE", this, valueStart, valueEnd, value));
         this.currentRule.declarations.end = this.stream.pos;
         this._bindCurrentRule();
         this.stream.markTokenStartAfterSpace();
@@ -1411,13 +1443,16 @@
       // First we check to see if the beginning of our stream is
       // an HTML5 doctype tag. We're currently quite strict and don't
       // parse XHTML or other doctypes.
-      if (this.stream.match(this.html5Doctype, true, true))
+      if (this.stream.match(this.html5Doctype, true, true)) {
         this.domBuilder.fragment.parseInfo = {
           doctype: {
             start: 0,
             end: this.stream.pos
           }
         };
+      } else {
+        this.warnings.push(new ParseError("NO_DOCTYPE_FOUND"));
+      }
 
       // Next, we parse "tag soup", creating text nodes and diving into
       // tags as we find them.
@@ -1435,6 +1470,11 @@
       // we test for that.
       if (this.domBuilder.currentNode != this.domBuilder.fragment)
         throw new ParseError("UNCLOSED_TAG", this);
+
+      if (this.domBuilder.currentNode.children &&
+        (this.domBuilder.currentNode.children.length !== 1 || this.domBuilder.currentNode.firstElementChild.tagName !== "HTML")) {
+        this.warnings.push(new ParseError("HTML_NOT_ROOT_ELEMENT", this));
+      }
 
       return {
         warnings: (this.warnings.length > 0 ? this.warnings : false)

--- a/js/output/webpage/webpage-output.js
+++ b/js/output/webpage/webpage-output.js
@@ -190,6 +190,8 @@ window.WebpageOutput = Backbone.View.extend({
         // Mostly borrowed from:
         // https://github.com/mozilla/thimble.webmaker.org/blob/master/locale/en_US/thimble-dialog-messages.json
         return ({
+            NO_DOCTYPE_FOUND: $._("A DOCTYPE declaration should be the first item on the page.", error),
+            HTML_NOT_ROOT_ELEMENT: $._("The root element on the page should be an <html> element.", error),
             ATTRIBUTE_IN_CLOSING_TAG: $._("A closing \"&lt;/%(closeTag_name)s&gt;\" tag cannot contain any attributes.", error),
             CLOSE_TAG_FOR_VOID_ELEMENT: $._("You have a closing \"&lt;/%(closeTag_name)s&gt;\" tag for a void element (and void elements don't need to be closed).", error),
             CSS_MIXED_ACTIVECONTENT: $._("You have a css property \"%(cssProperty_property)s\" with a \"url()\" value that currently points to an insecure resource.", error),
@@ -201,6 +203,7 @@ window.WebpageOutput = Backbone.View.extend({
             UNSUPPORTED_ATTR_NAMESPACE: $._("The attribute \"%(attribute_name_value)s\" uses an attribute namespace that is not permitted under HTML5 conventions.", error),
             MULTIPLE_ATTR_NAMESPACES: $._("The attribute \"%(attribute_name_value)s\" has multiple namespaces. Check your text and make sure there's only a single namespace prefix for the attribute.", error),
             INVALID_CSS_PROPERTY_NAME: $._("The CSS property \"%(cssProperty_property)s\" does not exist.", error),
+            IMPROPER_CSS_VALUE: $._("The CSS value \"%(cssValue_value)s\" is malformed.", error),
             INVALID_TAG_NAME: $._("A \"&lt;\" character appears to be the beginning of a tag, but is not followed by a valid tag name. If you want a \"&lt;\" to appear on your Web page, try using \"&amp;lt;\" instead. Otherwise, check your spelling.", error),
             JAVASCRIPT_URL_NOT_ALLOWED: $._("Sorry, but security restrictions on this site prevent you from using the \"javascript:\" URL.", error),
             MISMATCHED_CLOSE_TAG: $._("You have a closing \"&lt;/%(closeTag_name)s&gt;\" tag that doesn't pair with the opening \"&lt;%(openTag_name)s&gt;\" tag. This is likely due to a missing or misordered \"&lt;/%(openTag_name)s&gt;\" tag.", error),

--- a/tests/output/webpage/output_test.js
+++ b/tests/output/webpage/output_test.js
@@ -122,27 +122,45 @@ describe("Linting", function() {
         '<button type="submit">Submit</button>'
     ]);
 
-    warningTest('links with invalid protocols are banned', [
-        "<a href='www.google.com'></a>",
-        "<a href='google.com'></a>",
-        "<script src='www.google.com'></script>"
+    warningTest('links with invalid protocols throw warnings', [
+        "<!DOCTYPE html><html><a href='www.google.com'></a></html>",
+        "<!DOCTYPE html><html><a href='google.com'></a></html>",
+        "<!DOCTYPE html><html><script src='www.google.com'></script></html>"
     ], [
         ["The <a> tag's \"href\" attribute points to an invalid URL.  Did you include the protocol (http:// or https://)?"],
         ["The <a> tag's \"href\" attribute points to an invalid URL.  Did you include the protocol (http:// or https://)?"],
         ["The <script> tag's \"src\" attribute points to an invalid URL.  Did you include the protocol (http:// or https://)?"]
     ]);
 
-    warningTest('links with invalid protocols are banned', [
-      '<a href="http://google.com"></a>',
-      '<a href="https://google.com"></a>',
-      '<script src="//ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.js"></script>',
-      '<a href="ftp://google.com"></a>',
-      '<a href="mailto:khan@ka.com"></a>'
+    warningTest('links with valid protocols do not throw warnings', [
+      '<!DOCTYPE html><html><a href="http://google.com"></a></html>',
+      '<!DOCTYPE html><html><a href="https://google.com"></a></html>',
+      '<!DOCTYPE html><html><script src="//ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.js"></script></html>',
+      '<!DOCTYPE html><html><a href="ftp://google.com"></a></html>',
+      '<!DOCTYPE html><html><a href="mailto:khan@ka.com"></a</html>>'
     ], [[], [], [], [], []]);
 
-    warningTest("in-page links are not banned", '<a href="#foobar"></a>', []);
-    warningTest("javascript hrefs are not banned", '<a href="javascript:void(0)"></a>', []);
-    warningTest("regular scripts are not banned", '<script src="http://google.com"></script>', []);
+    warningTest("in-page links are not banned", '<!DOCTYPE html><html><a href="#foobar"></a></html>', []);
+    warningTest("javascript hrefs are not banned", '<!DOCTYPE html><html><a href="javascript:void(0)"></a></html>', []);
+    warningTest("regular scripts are not banned", '<!DOCTYPE html><html><script src="http://google.com"></script></html>', []);
+
+    warningTest("missing DOCTYPE", "<html><body></body></html>",
+      ["A DOCTYPE declaration should be the first item on the page."]
+    );
+
+    warningTest("non-html root element", '<!DOCTYPE html><a href="#foobar"></a>',
+      ["The root element on the page should be an <html> element."]
+    );
+
+    warningTest("forgetting CSS values in a <style> block throw a warning",
+      '<!DOCTYPE html><html><style>.photo {\nborder: 2px, double, red;\nmargin-left:5px;\nwidth: 200px;\ncolor: blue\n}</style></html>',
+      ['The CSS value \"blue\" still needs to be finalized with \";\"']
+    );
+
+    warningTest("color values with a space throw a warning",
+      '<!DOCTYPE html><html><style>\n.photo {\ncolor: rgb (255, 255, 255);\n}\n</style></html>',
+      ['The CSS value \"rgb (255, 255, 255)\" is malformed.']
+    );
 
     failingTest("INVALID_TAG_NAME raised by < at EOF",
         '<', [


### PR DESCRIPTION
Uses the warnings array introduced #403 to display these problems as gutter errors, but letting it render as is.

Fixes #271, #268, #425.