### PR TITLE
Resolve #407

### DIFF
--- a/build/js/live-editor.output_pjs_deps.js
+++ b/build/js/live-editor.output_pjs_deps.js
@@ -87701,7 +87701,6 @@ ASTTransforms.rewriteContextVariables = function (envName, context) {
                     }
                 }
             } else if (node.type === "VariableDeclaration") {
-
                 if (node.declarations.length === 1) {
                     // Single VariableDeclarators
 
@@ -87720,7 +87719,7 @@ ASTTransforms.rewriteContextVariables = function (envName, context) {
                     // that appear in the global scope unless it's one of the draw loop
                     // methods.  In that case, always rewrite it.
                     if (scopes.length === 1 || drawLoopMethods.includes(decl.id.name)) {
-                        if (["Program", "BlockStatement"].includes(parent.type)) {
+                        if (["Program", "BlockStatement"].includes(parent.type) || ["FunctionExpression"].includes(decl.init.type)) {
                             return b.ExpressionStatement(b.AssignmentExpression(b.MemberExpression(b.Identifier(envName), b.Identifier(decl.id.name)), "=", decl.init));
                         } else {
                             if (["ForStatement"].includes(parent.type)) {

--- a/js/output/pjs/pjs-ast-transforms.js
+++ b/js/output/pjs/pjs-ast-transforms.js
@@ -131,7 +131,6 @@ ASTTransforms.rewriteContextVariables = function(envName, context) {
                     }
                 }
             } else if (node.type === "VariableDeclaration") {
-
                 if (node.declarations.length === 1) {
                     // Single VariableDeclarators
 
@@ -150,10 +149,13 @@ ASTTransforms.rewriteContextVariables = function(envName, context) {
                     // that appear in the global scope unless it's one of the draw loop
                     // methods.  In that case, always rewrite it.
                     if (scopes.length === 1 || drawLoopMethods.includes(decl.id.name)) {
-                        if (["Program", "BlockStatement"].includes(parent.type)) {
+                        if (["Program", "BlockStatement"].includes(parent.type)
+                                || ["FunctionExpression"].includes(decl.init.type)) {
                             return b.ExpressionStatement(
                                 b.AssignmentExpression(
-                                    b.MemberExpression(b.Identifier(envName),b.Identifier(decl.id.name)),
+                                    b.MemberExpression(
+                                        b.Identifier(envName),
+                                        b.Identifier(decl.id.name)),
                                     "=",
                                     decl.init
                                 )

--- a/tests/output/pjs/ast_transform_tests.js
+++ b/tests/output/pjs/ast_transform_tests.js
@@ -13,7 +13,7 @@ var cleanupCode = function(code) {
 var transformCode = function(code) {
     var ast = esprima.parse(code);
     var envName = "__env__";
-    
+
     // The tests use ellipse(), console.log(), and print() so we need to make
     // sure they're defined in the context object otherwise the transform won't
     // prefix them when they're used inside of a function body.
@@ -36,16 +36,16 @@ describe("AST Transforms", function () {
                 ellipse(25 * i, 200, 50, 50);
             }
         }));
-        
+
         var expectedCode = cleanupCode(getCodeFromOptions(function() {
             for (__env__.i = 0; __env__.i < 10; __env__.i++) {
                 __env__.ellipse(25 * __env__.i, 200, 50, 50);
             }
         }));
-        
+
         expect(transformedCode).to.equal(expectedCode);
     });
-    
+
     it("should handle event handlers declared inside 'draw'", function () {
         var transformedCode = transformCode(getCodeFromOptions(function() {
             var draw = function() {
@@ -81,7 +81,7 @@ describe("AST Transforms", function () {
 
         expect(transformedCode).to.equal(expectedCode);
     });
-    
+
     it("should handle built-in identifiers", function () {
         var transformedCode = transformCode(getCodeFromOptions(function() {
             var x = undefined;
@@ -140,7 +140,7 @@ describe("AST Transforms", function () {
     it("should handle draw loop functions inside 'draw'", function () {
         var transformedCode = transformCode(getCodeFromOptions(function() {
             var draw = function() {
-                var x = 5, mouseClicked = function () {}, y = 10;  
+                var x = 5, mouseClicked = function () {}, y = 10;
             };
         }));
 
@@ -180,5 +180,37 @@ describe("AST Transforms", function () {
         }));
 
         expect(transformedCode).to.equal(expectedCode);
+    });
+
+    it("should prefix functions declared inside of 'switch/case' statements with '__env__'", function() {
+        var transformedCode = transformCode(getCodeFromOptions(function() {
+            var a = 0;
+            switch (a) {
+                case 0:
+                    var myFunc = function() {
+                        print("Hello, world!");
+                    };
+
+                    myFunc();
+                    break;
+                default:
+                    break;
+            }
+        }));
+
+        var expectedCode = cleanupCode(getCodeFromOptions(function() {
+            __env__.a = 0;
+            switch (__env_.a) {
+                case 0:
+                    __env__.myFunc = function() {
+                        __env__.print("Hello, world!");
+                    };
+
+                    __env__.myFunc();
+                    break;
+                default:
+                    break;
+            }
+        }));
     });
 });


### PR DESCRIPTION
This change fixes #407, which prevented users from invoking function that were declared from switch/case statements.

Minor changes:
 * Checked variable declaration's "init" node type. If it's a `FunctionExpression`, perform the AST transform that is used to prefix functions with `__env__`.

Major changes:
 * None.

**Please note**: I haven't written any tests for this yet, as I didn't know if they'd be necessary. If required, I *will* write a test for this.

To test this change manually:
 * Point your browser to `demos/simple`
 * Insert the following code:
```javascript
var a = 0;

switch (a) {
    case 0:
        var doTest = function() {
            println("This is a test, only a test!");
        };
        doTest();
        break;
    default:
        break;
}
```

You should see "This is a test, only a test!" printed to the PJS console.

Gigabyte Giant (brynden.bielefeld@hotmail.com)