### PR TITLE
Add Gutter Warning for Obsolete HTML Tags in the Webpage Environment

### DIFF
--- a/build/js/live-editor.output_webpage.js
+++ b/build/js/live-editor.output_webpage.js
@@ -759,6 +759,7 @@ window.WebpageOutput = Backbone.View.extend({
             MISSING_CSS_SELECTOR: $._("You're missing either a new CSS selector or the \"&lt;/style&gt;\" tag.", error),
             MISSING_CSS_VALUE: $._("You're missing value for \"%(cssProperty_property)s\".", error),
             SCRIPT_ELEMENT_NOT_ALLOWED: $._("Sorry, but security restrictions on this site prevent you from using \"&lt;script&gt;\" tags.", error),
+            OBSOLETE_HTML_TAG: $._("The \"%(openTag_name)s\" tag is obsolete and may not function properly in modern browsers.", error),
             ELEMENT_NOT_ALLOWED: $._("Sorry, but security restrictions on this site prevent you from using \"&lt;%(openTag_name)s&gt;\" tags.", error),
             SELF_CLOSING_NON_VOID_ELEMENT: $._("The \"&lt;%(name)s&gt;\" tag can't be self-closed, because \"&lt;%(name)s&gt;\" is not a void element; it must be closed with a separate \"&lt;/%(name)s&gt;\" tag.", error),
             UNCAUGHT_CSS_PARSE_ERROR: $._("A parse error occurred outside expected cases: \"%(error_msg)s\"", error),

--- a/external/slowparse/slowparse.js
+++ b/external/slowparse/slowparse.js
@@ -195,6 +195,15 @@
         cursor: openTag.start
       };
     },
+    OBSOLETE_HTML_TAG: function(tagName, token) {
+      var openTag = this._combine({
+          name: tagName
+        }, token.interval);
+      return {
+        openTag: openTag,
+        cursor: openTag.start
+      }
+    },
     ELEMENT_NOT_ALLOWED: function(tagName, token) {
       var openTag = this._combine({
             name: tagName
@@ -1348,8 +1357,9 @@
     // We also keep a list of HTML elements that are now obsolete, but
     // may still be encountered in the wild on popular sites.
     obsoleteHtmlElements: ["acronym", "applet", "basefont", "big", "center",
-                           "dir", "font", "isindex", "listing", "noframes",
-                           "plaintext", "s", "strike", "tt", "xmp"],
+                           "dir", "font", "isindex", "listing", "marquee",
+                           "noframes", "plaintext", "s", "strike", "tt",
+                           "xmp"],
 
     webComponentElements: ["template", "shadow", "content"],
 
@@ -1379,6 +1389,12 @@
     // is a void HTML element tag.
     _knownVoidHTMLElement: function(tagName) {
       return this.voidHtmlElements.indexOf(tagName) > -1;
+    },
+
+    // This is a helper function to determine whether a given string
+    // is an obsolete HTML element tag
+    _knownObsoleteHTMLElement: function(tagName) {
+      return this.obsoleteHtmlElements.indexOf(tagName) > -1;
     },
 
     // This is a helper function to determine whether a given string
@@ -1500,8 +1516,11 @@
         if (tagName) {
           var badSVG = this.parsingSVG && !this._knownSVGElement(tagName);
           var badHTML = !this.parsingSVG && !this._knownHTMLElement(tagName) && !this._isCustomElement(tagName);
+          var obsoleteHTML = this._knownObsoleteHTMLElement(tagName);
           if (badSVG || badHTML) {
             throw new ParseError("INVALID_TAG_NAME", tagName, token);
+          } else if (obsoleteHTML) {
+            this.warnings.push(new ParseError("OBSOLETE_HTML_TAG", tagName, token));
           } else if (this.options.noScript && tagName === "script") {
             throw new ParseError("SCRIPT_ELEMENT_NOT_ALLOWED", tagName, token);
           } else if (this.options.disableTags) {

--- a/js/output/webpage/webpage-output.js
+++ b/js/output/webpage/webpage-output.js
@@ -210,6 +210,7 @@ window.WebpageOutput = Backbone.View.extend({
             MISSING_CSS_SELECTOR: $._("You're missing either a new CSS selector or the \"&lt;/style&gt;\" tag.", error),
             MISSING_CSS_VALUE: $._("You're missing value for \"%(cssProperty_property)s\".", error),
             SCRIPT_ELEMENT_NOT_ALLOWED: $._("Sorry, but security restrictions on this site prevent you from using \"&lt;script&gt;\" tags.", error),
+            OBSOLETE_HTML_TAG: $._("The \"%(openTag_name)s\" tag is obsolete and may not function properly in modern browsers.", error),
             ELEMENT_NOT_ALLOWED: $._("Sorry, but security restrictions on this site prevent you from using \"&lt;%(openTag_name)s&gt;\" tags.", error),
             SELF_CLOSING_NON_VOID_ELEMENT: $._("The \"&lt;%(name)s&gt;\" tag can't be self-closed, because \"&lt;%(name)s&gt;\" is not a void element; it must be closed with a separate \"&lt;/%(name)s&gt;\" tag.", error),
             UNCAUGHT_CSS_PARSE_ERROR: $._("A parse error occurred outside expected cases: \"%(error_msg)s\"", error),

--- a/tests/output/webpage/output_test.js
+++ b/tests/output/webpage/output_test.js
@@ -144,6 +144,16 @@ describe("Linting", function() {
     warningTest("javascript hrefs are not banned", '<a href="javascript:void(0)"></a>', []);
     warningTest("regular scripts are not banned", '<script src="http://google.com"></script>', []);
 
+    warningTest("obsolete HTML elements warned against", [
+        "<marquee></marquee>",
+        "<marquee>Some clever message</marquee>",
+        "<acronym title=\"World Wide Web\">WWW</acronym>"
+    ], [
+        ["The \"marquee\" tag is obsolete and may not function properly in modern browsers."],
+        ["The \"marquee\" tag is obsolete and may not function properly in modern browsers."],
+        ["The \"acronym\" tag is obsolete and may not function properly in modern browsers."]
+    ])
+
     failingTest("INVALID_TAG_NAME raised by < at EOF",
         '<', [
             {row: 0, column: 0, lint: {type: "INVALID_TAG_NAME"}}


### PR DESCRIPTION
This pull request implements the feature suggested in #434, displaying a gutter warning in the webpage environment when obsolete HTML tags are used

## Changes
### Major
#### external/slowparse/slowparse.js

* Add a `OBSOLETE_HTML_TAG` error
* Create a warning when an obsolete HTML tag is detected in the document

#### js/output/webpage/webpage-output.js

* Add a warning message for obsolete HTML tags

Thank you for your time and consideration!