### PR TITLE
Separate AST Transform to rewrite NewExpressions

### DIFF
--- a/build/js/live-editor.output_pjs.js
+++ b/build/js/live-editor.output_pjs.js
@@ -648,13 +648,6 @@ var PJSCodeInjector = (function () {
             // Extract a list of instances that were created using applyInstance
             PJSOutput.instances = [];
 
-            // Replace all calls to 'new Something' with
-            // this.newInstance(Something)()
-            // Used for keeping track of unique instances
-            if (!this["debugger"]) {
-                userCode = userCode && userCode.replace(/\bnew[\s\n]+([A-Z]{1,2}[a-zA-Z0-9_]+)([\s\n]*\()/g, "PJSOutput.applyInstance($1,'$1')$2");
-            } else {}
-
             // If we have a draw function then we need to do injection
             // If we had a draw function then we still need to do injection
             // to clean up any live variables.
@@ -1035,6 +1028,10 @@ var PJSCodeInjector = (function () {
             // Program.assertEquals.
             astTransformPasses.push(ASTTransforms.rewriteAssertEquals);
 
+            // rewriteNewExpressions transforms 'NewExpression's into
+            //  'CallExpression's.
+            astTransformPasses.push(ASTTransforms.rewriteNewExpressions(envName, context));
+
             try {
                 walkAST(ast, null, astTransformPasses);
             } catch (e) {
@@ -1228,9 +1225,6 @@ var PJSCodeInjector = (function () {
 
 // TODO(kevinb) convert to a commonjs module at somepoint in the future
 window.PJSCodeInjector = PJSCodeInjector;
-
-// we'll use the debugger's newCallback delegate method to
-// keep track of object instances
 
 // Ignore any errors that were generated in the callback
 // NOTE(jeresig): This is needed because Mocha throws errors

--- a/build/js/live-editor.output_pjs_deps.js
+++ b/build/js/live-editor.output_pjs_deps.js
@@ -87848,3 +87848,13 @@ ASTTransforms.findResources = function (resources) {
         }
     };
 };
+
+ASTTransforms.rewriteNewExpressions = function (envName) {
+    return {
+        leave: function leave(node, path) {
+            if (node.type === "NewExpression") {
+                return b.CallExpression(b.CallExpression(b.MemberExpression(b.MemberExpression(b.Identifier(envName), b.Identifier("PJSOutput")), b.Identifier("applyInstance")), [b.MemberExpression(b.Identifier(envName), b.Identifier(node.callee.name)), b.Literal(node.callee.name)]), node.arguments);
+            }
+        }
+    };
+};

--- a/js/output/pjs/pjs-ast-transforms.js
+++ b/js/output/pjs/pjs-ast-transforms.js
@@ -300,3 +300,31 @@ ASTTransforms.findResources = function(resources) {
         }
     };
 };
+
+ASTTransforms.rewriteNewExpressions = function(envName) {
+    return {
+        leave(node, path) {
+            if (node.type === "NewExpression") {
+                return b.CallExpression(
+                    b.CallExpression(
+                        b.MemberExpression(
+                            b.MemberExpression(
+                                b.Identifier(envName),
+                                b.Identifier("PJSOutput")
+                            ),
+                            b.Identifier("applyInstance")
+                        ),
+                        [
+                            b.MemberExpression(
+                                b.Identifier(envName),
+                                b.Identifier(node.callee.name)
+                            ),
+                            b.Literal(node.callee.name)
+                        ]
+                    ),
+                    node.arguments
+                );
+            }
+        }
+    }
+};

--- a/js/output/pjs/pjs-code-injector.js
+++ b/js/output/pjs/pjs-code-injector.js
@@ -588,18 +588,6 @@ class PJSCodeInjector {
         // Extract a list of instances that were created using applyInstance
         PJSOutput.instances = [];
 
-        // Replace all calls to 'new Something' with
-        // this.newInstance(Something)()
-        // Used for keeping track of unique instances
-        if (!this.debugger) {
-            userCode = userCode && userCode.replace(
-                    /\bnew[\s\n]+([A-Z]{1,2}[a-zA-Z0-9_]+)([\s\n]*\()/g,
-                    "PJSOutput.applyInstance($1,'$1')$2");
-        } else {
-            // we'll use the debugger's newCallback delegate method to
-            // keep track of object instances
-        }
-
         // If we have a draw function then we need to do injection
         // If we had a draw function then we still need to do injection
         // to clean up any live variables.
@@ -996,6 +984,10 @@ class PJSCodeInjector {
         // rewriteAssertEquals adds line and column arguments to calls to
         // Program.assertEquals.
         astTransformPasses.push(ASTTransforms.rewriteAssertEquals);
+
+        // rewriteNewExpressions transforms 'NewExpression's into
+        //  'CallExpression's.
+        astTransformPasses.push(ASTTransforms.rewriteNewExpressions(envName, context));
 
         try {
             walkAST(ast, null, astTransformPasses);

--- a/tests/output/pjs/ast_transform_test.js
+++ b/tests/output/pjs/ast_transform_test.js
@@ -211,6 +211,24 @@ describe("AST Transforms", function () {
 
         expect(expectedCode).to.equal(transformedCode);
     });
+
+    it("should substitute all 'NewExpression's with 'CallExpression's to '__env__.PJSOutput.applyInstance'", function() {
+        var transformedCode = transformCode(getCodeFromOptions(function() {
+            var Obj = function (prop) {
+                this.prop = prop;
+            };
+
+            var myInstance = new Obj(1);
+        }));
+
+        var expectedCode = cleanupCode(getCodeFromOptions(function() {
+            __env__.Obj = function (prop) {
+                this.prop = prop;
+            };
+
+            __env__.myInstance = __env__.PJSOutput.applyInstance(__env__.Obj, 'Obj')(1);
+        }));
+    });
 });
 
 describe("AST Transforms for exporting", function() {

--- a/tests/output/pjs/output_test.js
+++ b/tests/output/pjs/output_test.js
@@ -6,7 +6,7 @@ describe("Version test", function() {
     it("should use version 4 or greater", function() {
         var config = new ScratchpadConfig({});
         expect(config.latestVersion()).to.be(4);
-    });  
+    });
 });
 
 // Test the lower level functions in Output
@@ -57,7 +57,7 @@ describe("Scratchpad Output Exec", function() {
     [{column: 0}]);
 
     failingTest("JSHint Error", "ellipse(x, 100, 100, 100);");
-    
+
     failingTest(
         "KAInfiniteLoopCount is not allowed",
         "KAInfiniteLoopCount = 0;"
@@ -72,7 +72,7 @@ describe("Scratchpad Output Exec", function() {
         "KAInfiniteLoopProtect is not allowed",
         "KAInfiniteLoopProtect();"
     );
-    
+
     failingTest(
         "props on __env__ cannot be accessed directly",
         "__env__.fill = function() { debug('foo'); }"
@@ -87,7 +87,7 @@ describe("Scratchpad Output Exec", function() {
         "__env__ cannot be declared",
         "var __env__ = {};"
     );
-    
+
     failingTest(
         "generates an error for numbers prefixed by a 0",
         "ellipse(09,10,11,12);"
@@ -120,7 +120,7 @@ describe("Scratchpad Output Exec", function() {
             debug(e);
         }
     });
-    
+
     test("arguments special object/array", function() {
         var foo = function() {
             var x = arguments[0];
@@ -533,7 +533,7 @@ describe("Scratchpad Output Exec", function() {
         };
 
     });
-    
+
     runTest({
         title: "Make sure methods on objects returned by createGraphics work",
         code: function() {
@@ -814,7 +814,7 @@ describe("Scratchpad Output Exec", function() {
         errors: [],
         assertions: []
     });
-    
+
     runTest({
         title: "local variables in closure of global draw should update",
         code: function() {
@@ -887,23 +887,6 @@ describe("Scratchpad Output Exec", function() {
             p.ellipse.restore();
         },
         wait: 500
-    });
-
-    runTest({
-        title: "should transform constructors with multiple capital letters",
-        code: function() {
-            var CommandQueue = function() {};
-            var commandQueue = new CommandQueue();
-        },
-        setup: function(output) {
-            sinon.spy(output.output.injector, "exec");
-        },
-        teardown: function(output) {
-            var code = output.output.injector.exec.getCall(0).args[0];
-            expect(code).to.contain("PJSOutput.applyInstance(CommandQueue,'CommandQueue')()");
-            expect(code).to.not.contain("new CommandQueue");
-            output.output.injector.exec.restore();
-        }
     });
 
     runTest({


### PR DESCRIPTION
This PR contains the changes that @kevinbarabash suggested to me to fix #324.
Currently, the live-editor performs a string replacement to replace any and all instances of *anything* that matches the following Regex:
```
/\bnew[\s\n]+([A-Z]{1,2}[a-zA-Z0-9_]+)([\s\n]*\()/g
```

Anything that matches that Regex is replaced with the following:

```
PJSOutput.applyInstance($1,'$1')$2");
```

In the end, the following code...
```javascript
var Obj = function(prop) {
    this.prop = prop;
};

var myObj = new Obj(10);
```
...gets changed to...
```javascript
__env__.Obj = function(prop) {
    this.prop = prop;
};

__env__.myObj = __env__.PJSOutput.applyInstance(__env__.Obj, 'Obj')(10);
```

The current approach would work fine, but, what about innocent strings? For example, see [this program](https://www.khanacademy.org/computer-programming/live-editor-bug-example/6383254823895040).

The problem is, the regular expression will also match things that are inside of strings.

This PR gets rid of the replacements, and instead, uses AST Transforms to transform all `NewExpression`s to `CallExpression`s.

The approach is quite different, **but the output is exactly the same**.

Notable changes:
 * I added an AST Transform that changes all `NewExpression`s with `CallExpression`s.
 * I ~~commented out~~ removed the string replacements that were originally used to achieve the same result.
 * I added an AST Transform test to make sure that the AST Transform worked correctly.

### A note to whoever reviews this:
Due to the fact that this is an entirely different approach than was taken before, some of the older tests fail (from what I can tell, it's only tests in `tests/output/pjs/output_test.js`)...
Can you tell me which tests are no longer valid? I've commented out one test that I found that might not be valid anymore (test title: "should transform constructors with multiple capital letters").

I'll squash my commits once I resolve the failing tests.

Gigabyte Giant (brynden.bielefeld@hotmail.com)