### PR TITLE
Fix improper handling of draw loop methods

### DIFF
--- a/js/output/pjs/pjs-ast-transforms.js
+++ b/js/output/pjs/pjs-ast-transforms.js
@@ -120,11 +120,10 @@ ASTTransforms.rewriteContextVariables = function(envName, context) {
                     }
 
                     // Prefix identifiers that exist in the context object and
-                    // have not been defined in any scope or are one of the draw
-                    // loop functions.  Also, prefix any other identifers that
+                    // have not been defined in any scope.
+                    // Also, prefix any other identifers that
                     // exist at the global scope.
                     if ((node.name in context && scopeIndex === -1) ||
-                            drawLoopMethods.includes(node.name) ||
                             scopeIndex === 0) {
                         return b.MemberExpression(
                             b.Identifier(envName), b.Identifier(node.name));
@@ -146,9 +145,9 @@ ASTTransforms.rewriteContextVariables = function(envName, context) {
 
                     // Rewrite all function declarations, e.g.
                     // var foo = function () {} => __env__.foo = function () {}
-                    // that appear in the global scope unless it's one of the draw loop
-                    // methods.  In that case, always rewrite it.
-                    if (scopes.length === 1 || drawLoopMethods.includes(decl.id.name)) {
+                    // that appear in the global scope. Draw loop methods aren't
+                    // special, they should be treated in the exact same way.
+                    if (scopes.length === 1) {
                         if (["Program", "BlockStatement", "SwitchCase"].includes(parent.type)) {
                             return b.ExpressionStatement(
                                 b.AssignmentExpression(
@@ -223,24 +222,14 @@ ASTTransforms.rewriteContextVariables = function(envName, context) {
                         // It should convert them to something like this:
                         // __env__.draw = function() {
                         //     var x = 5;
-                        //     __env__.mouseClicked = function () { ... };
+                        //     var mouseClicked = function () { ... };
                         //     var y = 10;
                         // };
-
+                        
                         return node.declarations
                             .filter(decl => decl.init !== null)
                             .map(decl => {
-                                if (drawLoopMethods.includes(decl.id.name)) {
-                                    return b.ExpressionStatement(
-                                        b.AssignmentExpression(
-                                            b.MemberExpression(b.Identifier(envName),b.Identifier(decl.id.name)),
-                                            "=",
-                                            decl.init
-                                        )
-                                    );
-                                } else {
-                                    return b.VariableDeclaration([decl], node.kind);
-                                }
+                                return b.VariableDeclaration([decl], node.kind);
                             });
                     }
                 }

--- a/tests/output/pjs/ast_transform_test.js
+++ b/tests/output/pjs/ast_transform_test.js
@@ -18,7 +18,8 @@ describe("AST Transforms", function () {
                 log: function() {}
             },
             print: function() {},
-            draw: function() {}
+            draw: function() {},
+            mouseClicked: function() {}
         };
 
         var injector = new PJSCodeInjector({ processing: context });
@@ -42,7 +43,7 @@ describe("AST Transforms", function () {
         expect(transformedCode).to.equal(expectedCode);
     });
 
-    it("should handle event handlers declared inside 'draw'", function () {
+    it("should handle event handlers declared inside 'draw' properly", function () {
         var transformedCode = transformCode(getCodeFromOptions(function() {
             var draw = function() {
                 var mouseClicked = function() {
@@ -52,7 +53,7 @@ describe("AST Transforms", function () {
 
         var expectedCode = cleanupCode(getCodeFromOptions(function() {
             __env__.draw = function () {
-                __env__.mouseClicked = function () {
+                var mouseClicked = function () {
                 };
             };
         }));
@@ -133,7 +134,7 @@ describe("AST Transforms", function () {
         expect(transformedCode).to.equal(expectedCode);
     });
 
-    it("should handle draw loop functions inside 'draw'", function () {
+    it("should handle draw loop functions inside 'draw' properly", function () {
         var transformedCode = transformCode(getCodeFromOptions(function() {
             var draw = function() {
                 var x = 5, mouseClicked = function () {}, y = 10;
@@ -143,9 +144,38 @@ describe("AST Transforms", function () {
         var expectedCode = cleanupCode(getCodeFromOptions(function() {
             __env__.draw = function () {
                 var x = 5;
-                __env__.mouseClicked = function () {
+                var mouseClicked = function () {
                 };
                 var y = 10;
+            };
+        }));
+
+        expect(transformedCode).to.equal(expectedCode);
+    });
+    
+    it("should handle methods in local scopes with the same names event handlers", function() {
+        var transformedCode = transformCode(getCodeFromOptions(function() {
+            var draw = function() {
+                var mouseClicked = function() {
+                    
+                };
+                var test = function() {
+                    mouseClicked = function() {
+                        println('If this ever prints: Bad times!');
+                    };
+                };
+            };
+        }));
+
+        var expectedCode = cleanupCode(getCodeFromOptions(function() {
+            __env__.draw = function () {
+                var mouseClicked = function () {
+                };
+                var test = function () {
+                    mouseClicked = function () {
+                        println('If this ever prints: Bad times!');
+                    };
+                };
             };
         }));
 


### PR DESCRIPTION
This pull request fixes improper handling of the draw loop methods reported in #445 and modifies the flawed tests that were checking this to be correct now.

# Major Changes

## js/output/pjs/pjs-ast-transform.js

* Delete some AST transform code that was causing improper behavior of draw loop methods in local scopes.
* Edit comments to help make sure that no one else makes this same mistake in the future.

# Minor Changes

## tests/output/pjs/ast_transform_test.js

* Edit flawed tests to test for the proper output

Thank you for your time.