### PR TITLE
Make errors for using advanced JS features friendlier

### DIFF
--- a/build/external/jshint/jshint.js
+++ b/build/external/jshint/jshint.js
@@ -58488,7 +58488,8 @@ var warnings = {
 	W101: i18n._("Line is too long."),
 	W102: i18n._("Trailing whitespace."),
 	W103: i18n._("The '{a}' property is deprecated."),
-	W104: i18n._("'{a}' is only available in JavaScript 1.7."),
+	W104: i18n._("'{a}' is only available in ES6 which is not supported by " + 
+        "this environment."),
 	W105: i18n._("Unexpected {a} in '{b}'."),
 	W106: i18n._("Identifier '{a}' is not in camel case."),
 	W107: i18n._("Script URL."),
@@ -58503,7 +58504,8 @@ var warnings = {
 	W117: i18n._("\"{a}\" is not defined. Make sure you're spelling it correctly " +
 		"and that you declared it."),
 	W118: i18n._("'{a}' is only available in Mozilla JavaScript extensions (use moz option)."),
-	W119: i18n._("'{a}' is only available in ES6 (use esnext option)."),
+	W119: i18n._("'{a}' is only available in ES6 which is not supported by " + 
+        "this environment."),
 	W120: i18n._("You might be leaking a variable ({a}) here."),
 	W121: i18n._("Extending prototype of native object: '{a}'."),
 	W122: i18n._("Invalid typeof value '{a}'"),

--- a/build/js/live-editor.output_pjs_deps.js
+++ b/build/js/live-editor.output_pjs_deps.js
@@ -78622,7 +78622,8 @@ var warnings = {
 	W101: i18n._("Line is too long."),
 	W102: i18n._("Trailing whitespace."),
 	W103: i18n._("The '{a}' property is deprecated."),
-	W104: i18n._("'{a}' is only available in JavaScript 1.7."),
+	W104: i18n._("'{a}' is only available in ES6 which is not supported by " + 
+        "this environment."),
 	W105: i18n._("Unexpected {a} in '{b}'."),
 	W106: i18n._("Identifier '{a}' is not in camel case."),
 	W107: i18n._("Script URL."),
@@ -78637,7 +78638,8 @@ var warnings = {
 	W117: i18n._("\"{a}\" is not defined. Make sure you're spelling it correctly " +
 		"and that you declared it."),
 	W118: i18n._("'{a}' is only available in Mozilla JavaScript extensions (use moz option)."),
-	W119: i18n._("'{a}' is only available in ES6 (use esnext option)."),
+	W119: i18n._("'{a}' is only available in ES6 which is not supported by " + 
+        "this environment."),
 	W120: i18n._("You might be leaking a variable ({a}) here."),
 	W121: i18n._("Extending prototype of native object: '{a}'."),
 	W122: i18n._("Invalid typeof value '{a}'"),

--- a/external/jshint/jshint.js
+++ b/external/jshint/jshint.js
@@ -58488,7 +58488,8 @@ var warnings = {
 	W101: i18n._("Line is too long."),
 	W102: i18n._("Trailing whitespace."),
 	W103: i18n._("The '{a}' property is deprecated."),
-	W104: i18n._("'{a}' is only available in JavaScript 1.7."),
+	W104: i18n._("'{a}' is only available in ES6 which is not supported by " + 
+        "this environment."),
 	W105: i18n._("Unexpected {a} in '{b}'."),
 	W106: i18n._("Identifier '{a}' is not in camel case."),
 	W107: i18n._("Script URL."),
@@ -58503,7 +58504,8 @@ var warnings = {
 	W117: i18n._("\"{a}\" is not defined. Make sure you're spelling it correctly " +
 		"and that you declared it."),
 	W118: i18n._("'{a}' is only available in Mozilla JavaScript extensions (use moz option)."),
-	W119: i18n._("'{a}' is only available in ES6 (use esnext option)."),
+	W119: i18n._("'{a}' is only available in ES6 which is not supported by " + 
+        "this environment."),
 	W120: i18n._("You might be leaking a variable ({a}) here."),
 	W121: i18n._("Extending prototype of native object: '{a}'."),
 	W122: i18n._("Invalid typeof value '{a}'"),


### PR DESCRIPTION
This pull request fixes #492 by editing the jshint messages for using ES7 and ES6 features to be worded in a more friendly and helpful way.

# Minor Changes

## external/jshint/jshint.js

* Switch W104 from "'some feature' is only available in JavaScript 1.7." to "It looks like you're trying to use 'some feature'. 'some feature' is a JavaScript 1.7 feature and is not currently supported in the live editor."

* Switch W109 from "'some feature' is only available in ES6 (use esnext option)." to "'some feature' is only available in ES6 which is not supported by the live editor at this point."

If any editing is required please let me know.

Thank you for your time.