### PR TITLE
Resolve regression bug #496

### DIFF
--- a/build/js/live-editor.output_pjs_deps.js
+++ b/build/js/live-editor.output_pjs_deps.js
@@ -87849,7 +87849,7 @@ ASTTransforms.rewriteNewExpressions = function (envName) {
     return {
         leave: function leave(node, path) {
             if (node.type === "NewExpression") {
-                return b.CallExpression(b.CallExpression(b.MemberExpression(b.MemberExpression(b.Identifier(envName), b.Identifier("PJSOutput")), b.Identifier("applyInstance")), [b.MemberExpression(b.Identifier(envName), b.Identifier(node.callee.name)), b.Literal(node.callee.name)]), node.arguments);
+                return b.CallExpression(b.CallExpression(b.MemberExpression(b.MemberExpression(b.Identifier(envName), b.Identifier("PJSOutput")), b.Identifier("applyInstance")), [node.callee, b.Literal(node.callee.name)]), node.arguments);
             }
         }
     };

--- a/js/output/pjs/pjs-ast-transforms.js
+++ b/js/output/pjs/pjs-ast-transforms.js
@@ -304,10 +304,7 @@ ASTTransforms.rewriteNewExpressions = function(envName) {
                             b.Identifier("applyInstance")
                         ),
                         [
-                            b.MemberExpression(
-                                b.Identifier(envName),
-                                b.Identifier(node.callee.name)
-                            ),
+                            node.callee,
                             b.Literal(node.callee.name)
                         ]
                     ),

--- a/tests/output/pjs/ast_transform_test.js
+++ b/tests/output/pjs/ast_transform_test.js
@@ -259,6 +259,32 @@ describe("AST Transforms", function () {
             __env__.myInstance = __env__.PJSOutput.applyInstance(__env__.Obj, 'Obj')(1);
         }));
     });
+
+    it("should not prefix function parameters when substituting 'NewExpression's with 'CallExpression's", function() {
+        var transformedCode = transformCode(getCodeFromOptions(function() {
+            var myObj = function () {
+
+            };
+
+            var makeObj = function (obj) {
+                return new obj();
+            };
+
+            var myInstance = makeObj(myObj);
+        }));
+
+        var expectedCode = cleanupCode(getCodeFromOptions(function() {
+            __env__.myObj = function () {
+
+            };
+
+            __env__.makeObj = function (obj) {
+                return __env__.PJSOutput.applyInstance(obj, 'obj')();
+            };
+
+            __env__.myInstance = __env__.makeObj(__env__.myObj);
+        }));
+    });
 });
 
 describe("AST Transforms for exporting", function() {


### PR DESCRIPTION
https://github.com/Khan/live-editor/issues/496 was caused due to the fact that the AST transform created in https://github.com/Khan/live-editor/commit/cd8f6dc529f387ad107a610a947254ff5ddbdbb2, was always prefixing identifiers with `__env__`.
Function parameters are not prefixed with `__env__`, therefore trying to reference  `__env__.someFunctionParam` would inevitably fail.

This commit adds a ternary-if-statement that checks to see if we're inside of a `FunctionExpression`. If we are, we don't prefix identifiers when we rewrite `NewExpression`s to `CallExpression`s.

I also added a test to make sure that this change did what it was supposed to do.

Gigabyte Giant (brynden.bielefeld@hotmail.com)