### PR TITLE
Replace CRLF line endings with LF endings

### DIFF
--- a/build/js/live-editor.editor_ace.js
+++ b/build/js/live-editor.editor_ace.js
@@ -392,7 +392,7 @@ window.AceEditor = Backbone.View.extend({
         if (_text != null) {
             this.editor.getSession().setValue(_text);
         } else {
-            return this.editor.getSession().getValue().replace(/\r/g, "\n");
+            return this.editor.getSession().getValue().replace(/\r\n/g, "\n");
         }
 
         return this;

--- a/js/editors/ace/editor-ace.js
+++ b/js/editors/ace/editor-ace.js
@@ -418,7 +418,7 @@ window.AceEditor = Backbone.View.extend({
         if (text != null) {
             this.editor.getSession().setValue(text);
         } else {
-            return this.editor.getSession().getValue().replace(/\r/g, "\n");
+            return this.editor.getSession().getValue().replace(/\r\n/g, "\n");
         }
 
         return this;


### PR DESCRIPTION
Minor change; just attempts to resolve #333, by replacing `\r\n` (CRLF) line endings, with `\n` (LF) line endings.

The original regular expression (`/\r/g`), was replacing `\r`s with `\n`s.
CRLF line endings are a combination of `\r`s and `\n`s.
If the original replace was run against code with CRLF line endings, you'd end up with something like `\n\n`.

This PR replaces `\r\n` with `\n`, so we don't get an extra `\n`.

Gigabyte Giant (brynden.bielefeld@hotmail.com)