### PR TITLE
Eliminate excess code-repetition in 'demos/simple/scratchpads.js'

### DIFF
--- a/demos/simple/scratchpads.js
+++ b/demos/simple/scratchpads.js
@@ -1,6 +1,6 @@
-var challengesDiv = document.getElementById('challenges');
-var officialDiv = document.getElementById('official');
-var tutorialsDiv = document.getElementById('tutorials');
+var challengesDiv = document.getElementById("challenges");
+var officialDiv = document.getElementById("official");
+var tutorialsDiv = document.getElementById("tutorials");
 
 var xhr = new XMLHttpRequest();
 xhr.open("GET", "scratchpads.json", false);
@@ -9,32 +9,24 @@ xhr.send();
 var scratchads = JSON.parse(xhr.responseText);
 var urlBase = "index.html?scratchpad=";
 
-scratchads.challenges.forEach(function(scratchpad) {
+var createScratchpadLink = function(scratchpad, divElem) {
     if (scratchpad.type === "pjs") {
-        var a = document.createElement('a');
+        var a = document.createElement("a");
         a.href = urlBase + scratchpad.id;
         a.innerText = scratchpad.title;
-        challengesDiv.appendChild(a);
-        challengesDiv.appendChild(document.createElement('br'));
+        divElem.appendChild(a);
+        divElem.appendChild(document.createElement("br"));
     }
+};
+
+scratchads.challenges.forEach(function(scratchpad) {
+    createScratchpadLink(scratchpad, challengesDiv);
 });
 
 scratchads.official.forEach(function(scratchpad) {
-    if (scratchpad.type === "pjs") {
-        var a = document.createElement('a');
-        a.href = urlBase + scratchpad.id;
-        a.innerText = scratchpad.title;
-        officialDiv.appendChild(a);
-        officialDiv.appendChild(document.createElement('br'));
-    }
+    createScratchpadLink(scratchpad, officialDiv);
 });
 
 scratchads.tutorials.forEach(function(scratchpad) {
-    if (scratchpad.type === "pjs") {
-        var a = document.createElement('a');
-        a.href = urlBase + scratchpad.id;
-        a.innerText = scratchpad.title;
-        tutorialsDiv.appendChild(a);
-        tutorialsDiv.appendChild(document.createElement('br'));
-    }
+    createScratchpadLink(scratchpad, tutorialsDiv);
 });


### PR DESCRIPTION
A minor change to `./demos/simple/scratchpads.js` that got rid of some code-repetition, by declaring a new function that would append a link to the specified `div`.

I also changed from single quotes to double quotes, for better consistency throughout the file.

Gigabyte Giant (brynden.bielefeld@hotmail.com)