### PR TITLE
Make KAInfiniteLoopSetTimeout More Secure

### DIFF
--- a/build/js/live-editor.output_pjs_deps.js
+++ b/build/js/live-editor.output_pjs_deps.js
@@ -87524,7 +87524,7 @@ window.LoopProtector.prototype = {
         } else {
             // Let the user know that what they're trying to do is a bad idea
             throw {
-                html: "Messing with the loop protector is dangerous!"
+                html: i18n._("Messing with the loop protector is dangerous!")
             };
         }
     },

--- a/build/js/live-editor.output_webpage_deps.js
+++ b/build/js/live-editor.output_webpage_deps.js
@@ -11995,7 +11995,7 @@ window.LoopProtector.prototype = {
         } else {
             // Let the user know that what they're trying to do is a bad idea
             throw {
-                html: "Messing with the loop protector is dangerous!"
+                html: i18n._("Messing with the loop protector is dangerous!")
             };
         }
     },

--- a/build/js/live-editor.output_webpage_deps.js
+++ b/build/js/live-editor.output_webpage_deps.js
@@ -11887,6 +11887,10 @@ window.walkAST = function (node, path, visitors) {
  * @constructor
  */
 window.LoopProtector = function (callback, timeouts, reportLocation) {
+    // protectorKey is used to check if a call to KAInfiniteLoopSetTimeout is
+    // by our own code, or if the call is just a users code trying to mess with
+    // things.
+    this.protectorKey = Math.random();
     this.callback = callback || function () {};
     this.timeout = 200;
     this.branchStartTime = 0;
@@ -11982,9 +11986,18 @@ window.LoopProtector.prototype = {
         }
     },
 
-    _KAInfiniteLoopSetTimeout: function _KAInfiniteLoopSetTimeout(timeout) {
-        this.timeout = timeout;
-        this.branchStartTime = 0;
+    _KAInfiniteLoopSetTimeout: function _KAInfiniteLoopSetTimeout(timeout, protectorKey) {
+        // Make sure that the key we've been provided matches the one on this
+        // LoopProtector
+        if (protectorKey === this.protectorKey) {
+            this.timeout = timeout;
+            this.branchStartTime = 0;
+        } else {
+            // Let the user know that what they're trying to do is a bad idea
+            throw {
+                html: "Messing with the loop protector is dangerous!"
+            };
+        }
     },
 
     riskyStatements: ["DoWhileStatement", "WhileStatement", "ForStatement", "FunctionExpression", "FunctionDeclaration"],
@@ -12022,7 +12035,7 @@ window.LoopProtector.prototype = {
             // the timeout to mainTimeout just to reset the value when the program
             // is re-run.
             if (this.mainTimeout) {
-                node.body.unshift(b.ExpressionStatement(b.CallExpression(b.Identifier("KAInfiniteLoopSetTimeout"), [b.Literal(this.mainTimeout)])));
+                node.body.unshift(b.ExpressionStatement(b.CallExpression(b.Identifier("KAInfiniteLoopSetTimeout"), [b.Literal(this.mainTimeout), b.Literal(this.protectorKey)])));
             }
 
             // Any asynchronous calls such as mouseClicked() or calls to draw()
@@ -12030,7 +12043,7 @@ window.LoopProtector.prototype = {
             // responsive as the app is running so we call KAInfiniteLoopSetTimeout
             // at the end of main and set timeout to be asyncTimeout
             if (this.asyncTimeout) {
-                node.body.push(b.ExpressionStatement(b.CallExpression(b.Identifier("KAInfiniteLoopSetTimeout"), [b.Literal(this.asyncTimeout)])));
+                node.body.push(b.ExpressionStatement(b.CallExpression(b.Identifier("KAInfiniteLoopSetTimeout"), [b.Literal(this.asyncTimeout), b.Literal(this.protectorKey)])));
             }
         }
     },

--- a/js/output/shared/loop-protect.js
+++ b/js/output/shared/loop-protect.js
@@ -115,7 +115,7 @@ window.LoopProtector.prototype = {
         } else {
             // Let the user know that what they're trying to do is a bad idea
             throw {
-                html: "Messing with the loop protector is dangerous!"
+                html: i18n._("Messing with the loop protector is dangerous!")
             };
         }
     },

--- a/js/output/shared/loop-protect.js
+++ b/js/output/shared/loop-protect.js
@@ -11,6 +11,10 @@
  * @constructor
  */
 window.LoopProtector = function(callback, timeouts, reportLocation) {
+    // protectorKey is used to check if a call to KAInfiniteLoopSetTimeout is
+    // by our own code, or if the call is just a users code trying to mess with
+    // things.
+    this.protectorKey = Math.random();
     this.callback = callback || function () { };
     this.timeout = 200;
     this.branchStartTime = 0;
@@ -102,9 +106,18 @@ window.LoopProtector.prototype = {
         }
     },
 
-    _KAInfiniteLoopSetTimeout: function (timeout) {
-        this.timeout = timeout;
-        this.branchStartTime = 0;
+    _KAInfiniteLoopSetTimeout: function (timeout, protectorKey) {
+        // Make sure that the key we've been provided matches the one on this
+        // LoopProtector
+        if (protectorKey === this.protectorKey) {
+            this.timeout = timeout;
+            this.branchStartTime = 0;
+        } else {
+            // Let the user know that what they're trying to do is a bad idea
+            throw {
+                html: "Messing with the loop protector is dangerous!"
+            };
+        }
     },
 
     riskyStatements: [
@@ -173,7 +186,7 @@ window.LoopProtector.prototype = {
                 node.body.unshift(
                     b.ExpressionStatement(b.CallExpression(
                         b.Identifier("KAInfiniteLoopSetTimeout"),
-                        [b.Literal(this.mainTimeout)]
+                        [b.Literal(this.mainTimeout), b.Literal(this.protectorKey)]
                     ))
                 );
             }
@@ -186,7 +199,7 @@ window.LoopProtector.prototype = {
                 node.body.push(
                     b.ExpressionStatement(b.CallExpression(
                         b.Identifier("KAInfiniteLoopSetTimeout"),
-                        [b.Literal(this.asyncTimeout)]
+                        [b.Literal(this.asyncTimeout), b.Literal(this.protectorKey)]
                     ))
                 );
             }

--- a/tests/output/pjs/output_test.js
+++ b/tests/output/pjs/output_test.js
@@ -92,6 +92,16 @@ describe("Scratchpad Output Exec", function() {
         "generates an error for numbers prefixed by a 0",
         "ellipse(09,10,11,12);"
     );
+    
+    failingTest(
+        "user calls to KAInfiniteLoopSetTimeout generate an error",
+        function() {
+            var begin = function() {
+                this[["KAInfiniteLoopSetTimeout"][0]](40000);
+            };
+            begin();
+        }
+    );
 
     test("Looping (with Processing.js Built-in Functions)", function() {
         var go = function() {


### PR DESCRIPTION
This pull request fixes #510 by making KAInfiniteLoopProtect more secure.
.
## Changes

* Add a pseudo randomly generated ID to instances of `LoopProtector` using `Math.random()`. This technique should be secure enough as it's not likely that someones code will be able to guess 15+ digits.

* Adds the loop protectors ID as an argument to all calls to `KAInfiniteLoopTimeout` that are generated in the AST transform.

* Edits `LoopProtector.prototype._KAInfiniteLoopSetTimeout` to accept an extra argument which should be the ID of the loop protector. If the ID that it is passed does not match the loop protectors ID then an error will be thrown.

Merging this PR may need to be delayed until after HOC. I'm pretty sure that I didn't break anything but it _is_ messing with a rather important part of the live editor for beginners. I would rather not be responsible for ruining a beginners day.

Thank you for your time!