### PR TITLE
Change color() and getImage() auto-complete to not insert ; as often. Fixes #262.

### DIFF
--- a/build/js/live-editor.tooltips.js
+++ b/build/js/live-editor.tooltips.js
@@ -1649,6 +1649,11 @@ window.TooltipBase = Backbone.View.extend({
         return parenStack.length > 0;
     },
 
+    // Returns true if we're after an `=` assignment
+    isAfterAssignment: function isAfterAssignment(text) {
+        return /(?:^|[^!=])=\s*$/.test(text);
+    },
+
     // Returns true if we're inside a string
     isWithinString: function isWithinString(text) {
         var withinString = false;
@@ -1843,7 +1848,7 @@ TooltipEngine.classes.colorPicker = TooltipBase.extend({
         if (event.source && event.source.action === "insertText" && event.source.text.length === 1 && this.parent.options.type === "ace_pjs" && this.autofill) {
             // Auto-close
             if (body.length === 0 && this.closing.length === 0) {
-                this.closing = ")" + (this.isInParenthesis(event.pre.slice(0, functionStart)) ? "" : ";");
+                this.closing = ")" + (this.isAfterAssignment(event.pre.slice(0, functionStart)) ? ";" : "");
                 this.insert({
                     row: event.row,
                     column: functionEnd
@@ -2268,7 +2273,7 @@ TooltipEngine.classes.imagePicker = TooltipBase.extend({
         // TODO(kevinb) extract this into a method on TooltipBase
         if (leadingPadding.length === 0 && path.length === 0 && this.closing.length === 0 && event.source && event.source.action === "insertText" && event.source.text.length === 1 && this.autofill) {
 
-            this.closing = ")" + (this.isInParenthesis(event.pre.slice(0, functionStart)) ? "" : ";");
+            this.closing = ")" + (this.isAfterAssignment(event.pre.slice(0, functionStart)) ? ";" : "");
             this.insert({
                 row: event.row,
                 column: pathStart

--- a/js/ui/tooltip-engine.js
+++ b/js/ui/tooltip-engine.js
@@ -331,6 +331,11 @@ window.TooltipBase = Backbone.View.extend({
         return parenStack.length > 0;
     },
 
+    // Returns true if we're after an `=` assignment
+    isAfterAssignment: function(text) {
+        return /(?:^|[^!=])=\s*$/.test(text);
+    },
+
     // Returns true if we're inside a string
     isWithinString: function(text) {
         var withinString = false;

--- a/js/ui/tooltips/color-picker.js
+++ b/js/ui/tooltips/color-picker.js
@@ -105,7 +105,7 @@ TooltipEngine.classes.colorPicker = TooltipBase.extend({
             event.source.text.length === 1 && this.parent.options.type === "ace_pjs" && this.autofill) {
             // Auto-close
             if (body.length === 0 && this.closing.length === 0) {
-                this.closing = ")" + (this.isInParenthesis(event.pre.slice(0, functionStart)) ? "" : ";");
+                this.closing = ")" + (this.isAfterAssignment(event.pre.slice(0, functionStart)) ? ";" : "");
                 this.insert({
                     row: event.row,
                     column: functionEnd

--- a/js/ui/tooltips/image-picker.js
+++ b/js/ui/tooltips/image-picker.js
@@ -34,7 +34,7 @@ TooltipEngine.classes.imagePicker = TooltipBase.extend({
         if (leadingPadding.length === 0 && path.length === 0 && this.closing.length === 0 &&
             event.source && event.source.action === "insertText" && event.source.text.length === 1 && this.autofill) {
 
-            this.closing = ")" + (this.isInParenthesis(event.pre.slice(0, functionStart)) ? "" : ";");
+            this.closing = ")" + (this.isAfterAssignment(event.pre.slice(0, functionStart)) ? ";" : "");
             this.insert({
                 row: event.row,
                 column: pathStart


### PR DESCRIPTION
I've changed the behavior so that the following now happens for both color and getImage:

No semicolon:

```
color(
var a = [color(
var a = [
    color(
foo(color(
foo(
    color(
if (a === color(
```

Semicolon:
```
var a = color(
```