### PR TITLE
Changes to structure()

### DIFF
--- a/build/workers/pjs/pjs-tester.js
+++ b/build/workers/pjs/pjs-tester.js
@@ -314,6 +314,11 @@ PJSTester.prototype.testMethods = {
      * constraint
      */
     structure: function(pattern, constraint) {
+        if (pattern && pattern.pattern) {   // Pattern is already a structure!
+            constraint = and(pattern.constraint, constraint);
+            pattern = pattern.pattern;
+        }
+        
         return {
             pattern: pattern,
             constraint: constraint


### PR DESCRIPTION
Makes patterns indistinguishable from structures, which is helpful if we want to have base patterns that include constraints, and build on top of those.
I considered multiple options to check for in the if clause and decided this is the best one because patterns can have many different types.
