### PR TITLE
Add semicolons unconditionally for fill/stroke function calls

### DIFF
--- a/build/js/live-editor.tooltips.js
+++ b/build/js/live-editor.tooltips.js
@@ -1845,10 +1845,16 @@ TooltipEngine.classes.colorPicker = TooltipBase.extend({
         };
         this.aceLocation.tooltipCursor = this.aceLocation.start + this.aceLocation.length + this.closing.length;
 
+        var name = event.line.substring(functionStart, paramsStart - 1);
+        var addSemicolon = this.isAfterAssignment(event.pre.slice(0, functionStart));
+        if (["fill", "stroke"].includes(name)) {
+            addSemicolon = true;
+        }
+
         if (event.source && event.source.action === "insertText" && event.source.text.length === 1 && this.parent.options.type === "ace_pjs" && this.autofill) {
             // Auto-close
             if (body.length === 0 && this.closing.length === 0) {
-                this.closing = ")" + (this.isAfterAssignment(event.pre.slice(0, functionStart)) ? ";" : "");
+                this.closing = ")" + (addSemicolon ? ";" : "");
                 this.insert({
                     row: event.row,
                     column: functionEnd

--- a/js/ui/tooltips/color-picker.js
+++ b/js/ui/tooltips/color-picker.js
@@ -101,11 +101,18 @@ TooltipEngine.classes.colorPicker = TooltipBase.extend({
         };
         this.aceLocation.tooltipCursor = this.aceLocation.start + this.aceLocation.length + this.closing.length;
 
-        if (event.source && event.source.action === "insertText" && 
+        var name = event.line.substring(functionStart, paramsStart - 1);
+        var addSemicolon =
+            this.isAfterAssignment(event.pre.slice(0, functionStart));
+        if (['fill', 'stroke'].includes(name)) {
+            addSemicolon = true;
+        }
+
+        if (event.source && event.source.action === "insertText" &&
             event.source.text.length === 1 && this.parent.options.type === "ace_pjs" && this.autofill) {
             // Auto-close
             if (body.length === 0 && this.closing.length === 0) {
-                this.closing = ")" + (this.isAfterAssignment(event.pre.slice(0, functionStart)) ? ";" : "");
+                this.closing = ")" + (addSemicolon ? ";" : "");
                 this.insert({
                     row: event.row,
                     column: functionEnd
@@ -122,7 +129,6 @@ TooltipEngine.classes.colorPicker = TooltipBase.extend({
                 this.updateText(rgb);
             }
         }
-        
 
         this.updateTooltip(rgb);
         this.placeOnScreen();


### PR DESCRIPTION
Since fill/stroke commands shouldn't appear as args to other
function calls it's okay to append a semicolon.

Test Plan:
- load http://localhost:63343/live-editor/demos/simple/index.html?new_error_experience=yes
- type fill( and see the semicolon being added at the end of the autocomplete
- do the same for stroke(
- type color( and see the semicolon not being added
- do the same for getImage(
- assign color( and getImage( to variables and verify that semicolons are being added