### PR TITLE
Date and Number allowed; Semicolon after background,

### DIFF
--- a/build/js/live-editor.output_pjs.js
+++ b/build/js/live-editor.output_pjs.js
@@ -166,6 +166,8 @@ var PJSCodeInjector = (function () {
                 this.processing.Array = window.Array;
                 this.processing.String = window.String;
                 this.processing.isNaN = window.isNaN;
+                this.processing.Number = window.Number;
+                this.processing.Date = window.Date;
             }
 
             Object.assign(this.processing, {
@@ -1754,7 +1756,8 @@ var BabyHint = {
         "textAlign": [1, 2],
         "textFont": [1, 2],
         "translate": [2, 3],
-        "vertex": [2, 4]
+        "vertex": [2, 4],
+        "Date": [0, 1, 2, 3, 4, 5, 6, 7]
     },
 
     // A mapping from function name to an example usage of the function

--- a/build/js/live-editor.output_pjs.js
+++ b/build/js/live-editor.output_pjs.js
@@ -340,13 +340,6 @@ var PJSCodeInjector = (function () {
             // Reset frameCount variable on restart
             this.processing.frameCount = 0;
 
-            for (var i = 0; i < this.drawLoopMethods.length; i++) {
-                this.processing[this.drawLoopMethods[i]] = undefined;
-            }
-            this.processing.keyPressed = function () {};
-            this.processing.keyReleased = function () {};
-            this.processing.draw = this.DUMMY;
-
             // Clear Processing logs
             this.processing._clearLogs();
         }

--- a/build/js/live-editor.output_pjs.js
+++ b/build/js/live-editor.output_pjs.js
@@ -340,6 +340,13 @@ var PJSCodeInjector = (function () {
             // Reset frameCount variable on restart
             this.processing.frameCount = 0;
 
+            for (var i = 0; i < this.drawLoopMethods.length; i++) {
+                this.processing[this.drawLoopMethods[i]] = undefined;
+            }
+            this.processing.keyPressed = function () {};
+            this.processing.keyReleased = function () {};
+            this.processing.draw = this.DUMMY;
+
             // Clear Processing logs
             this.processing._clearLogs();
         }

--- a/build/js/live-editor.tooltips.js
+++ b/build/js/live-editor.tooltips.js
@@ -1847,7 +1847,7 @@ TooltipEngine.classes.colorPicker = TooltipBase.extend({
 
         var name = event.line.substring(functionStart, paramsStart - 1);
         var addSemicolon = this.isAfterAssignment(event.pre.slice(0, functionStart));
-        if (["fill", "stroke"].includes(name)) {
+        if (["fill", "stroke", "background"].includes(name)) {
             addSemicolon = true;
         }
 

--- a/js/output/pjs/babyhint.js
+++ b/js/output/pjs/babyhint.js
@@ -112,7 +112,8 @@ var BabyHint = {
         "textAlign": [1, 2],
         "textFont": [1, 2],
         "translate": [2, 3],
-        "vertex": [2, 4]
+        "vertex": [2, 4],
+        "Date": [0, 1, 2, 3, 4, 5, 6, 7],
     },
 
     // A mapping from function name to an example usage of the function

--- a/js/output/pjs/pjs-code-injector.js
+++ b/js/output/pjs/pjs-code-injector.js
@@ -130,6 +130,8 @@ class PJSCodeInjector {
             this.processing.Array = window.Array;
             this.processing.String = window.String;
             this.processing.isNaN = window.isNaN;
+            this.processing.Number = window.Number;
+            this.processing.Date = window.Date;
         }
 
         Object.assign(this.processing, {

--- a/js/output/pjs/pjs-code-injector.js
+++ b/js/output/pjs/pjs-code-injector.js
@@ -302,15 +302,6 @@ class PJSCodeInjector {
         // Reset frameCount variable on restart
         this.processing.frameCount = 0;
 
-        // Reset all callbacks, so they don't persist across restarts
-        for (var i = 0; i < this.drawLoopMethods.length; i++) {
-            this.processing[this.drawLoopMethods[i]] = undefined;
-        }
-        this.processing.keyPressed = function () {};
-        this.processing.keyReleased = function () {};
-        this.processing.keyTyped = function () {};
-        this.processing.draw = this.DUMMY;
-
         // Clear Processing logs
         this.processing._clearLogs();
     }

--- a/js/output/pjs/pjs-code-injector.js
+++ b/js/output/pjs/pjs-code-injector.js
@@ -302,6 +302,15 @@ class PJSCodeInjector {
         // Reset frameCount variable on restart
         this.processing.frameCount = 0;
 
+        // Reset all callbacks, so they don't persist across restarts
+        for (var i = 0; i < this.drawLoopMethods.length; i++) {
+            this.processing[this.drawLoopMethods[i]] = undefined;
+        }
+        this.processing.keyPressed = function () {};
+        this.processing.keyReleased = function () {};
+        this.processing.keyTyped = function () {};
+        this.processing.draw = this.DUMMY;
+
         // Clear Processing logs
         this.processing._clearLogs();
     }

--- a/js/ui/tooltips/color-picker.js
+++ b/js/ui/tooltips/color-picker.js
@@ -104,7 +104,7 @@ TooltipEngine.classes.colorPicker = TooltipBase.extend({
         var name = event.line.substring(functionStart, paramsStart - 1);
         var addSemicolon =
             this.isAfterAssignment(event.pre.slice(0, functionStart));
-        if (['fill', 'stroke'].includes(name)) {
+        if (['fill', 'stroke', 'background'].includes(name)) {
             addSemicolon = true;
         }
 

--- a/tests/output/pjs/output_test.js
+++ b/tests/output/pjs/output_test.js
@@ -433,7 +433,15 @@ describe("Scratchpad Output Exec", function() {
     test("String object works", function() {
         var letter = String.fromCharCode(65);
     });
-
+    
+    test("Number object works", function() {
+        var newVal = Number.isFinite(1/0);
+    });
+    
+    test("Date object works", function() {
+        var newDate = Date.now();
+    });
+    
     test("Processing's parseFloat, parseInt work", function() {
         var settings = {};
         var val = parseInt(settings.val, 10) || 13;


### PR DESCRIPTION
I was just fixing some miscellaneous bugs I found, namely #450, #520, and an unreported issue where background doesn't autofill a semicolon after it. While this builds and runs fine, I have two questions before you merge this.
First, I [added an entry](https://github.com/Khan/live-editor/commit/79e36bb6666c7f7d9a45cc9a6d164fb38867d3a3) to `functionParamCount` for `Date`, in order to make BabyHint work with `new Date()`. I believe this same change should be applied to the [BabyHint repository itself](https://github.com/khan/babyhint), and would be willing to make a pull request there with the change. Second, I haven't updated pre-built version of the code with the use of `Date` or `Number`, and don't know how to do that (or if it needs to be done). I'm new at GitHub, so thanks for any help.