### PR TITLE
Fixed colorMode issue: Too many arguments passed!

### DIFF
--- a/build/js/live-editor.tooltips.js
+++ b/build/js/live-editor.tooltips.js
@@ -992,10 +992,10 @@ window.ScratchpadAutosuggestData = {
             description: i18n._("Calculates a color or colors between two color at a specific increment. The amount parameter is the amount to interpolate between the two values where 0.0 equal to the first point, 0.1 is very near the first point, 0.5 is half-way in between, etc."),
             params: [i18n._("c1: Interpolate from this color"), i18n._("c2: Interpolate to this color")]
         }, {
-            name: "colorMode(MODE)",
+            name: "colorMode(MODE, *range)",
             exampleURL: "/cs/colormode/5833774306689024",
             description: i18n._("Changes the way that color values are interpreted when set by fill()/stroke()/background()."),
-            params: [i18n._("MODE: Either RGB or HSB. The default is RGB.")]
+            params: [i18n._("MODE: Either RGB or HSB. The default is RGB."), i18n._("range (Optional): int or float: range for all color elements")]
         }, {
             name: "red(color)",
             exampleURL: "/cs/redcolor/5102159326609408",

--- a/build/js/live-editor.tooltips.js
+++ b/build/js/live-editor.tooltips.js
@@ -992,10 +992,10 @@ window.ScratchpadAutosuggestData = {
             description: i18n._("Calculates a color or colors between two color at a specific increment. The amount parameter is the amount to interpolate between the two values where 0.0 equal to the first point, 0.1 is very near the first point, 0.5 is half-way in between, etc."),
             params: [i18n._("c1: Interpolate from this color"), i18n._("c2: Interpolate to this color")]
         }, {
-            name: "colorMode(MODE, *range)",
+            name: "colorMode(MODE, *maxValue)",
             exampleURL: "/cs/colormode/5833774306689024",
             description: i18n._("Changes the way that color values are interpreted when set by fill()/stroke()/background()."),
-            params: [i18n._("MODE: Either RGB or HSB. The default is RGB."), i18n._("range (Optional): int or float: range for all color elements")]
+            params: [i18n._("MODE: Either RGB or HSB. The default is RGB."), i18n._("maxValue (Optional): number, maximum value for each color component.")]
         }, {
             name: "red(color)",
             exampleURL: "/cs/redcolor/5102159326609408",

--- a/build/js/live-editor.ui.js
+++ b/build/js/live-editor.ui.js
@@ -7,7 +7,7 @@ this["Handlebars"]["templates"]["tipbar"] = Handlebars.template(function (Handle
 function program1(depth0,data) {
   
   
-  return "x";}
+  return "&times;";}
 
 function program3(depth0,data) {
   

--- a/build/tmpl/tipbar.js
+++ b/build/tmpl/tipbar.js
@@ -7,7 +7,7 @@ this["Handlebars"]["templates"]["tipbar"] = Handlebars.template(function (Handle
 function program1(depth0,data) {
   
   
-  return "x";}
+  return "&times;";}
 
 function program3(depth0,data) {
   

--- a/js/ui/autosuggest-data.js
+++ b/js/ui/autosuggest-data.js
@@ -379,11 +379,12 @@ window.ScratchpadAutosuggestData = {
                 ]
             },
             {
-                name: "colorMode(MODE)",
+                name: "colorMode(MODE, *range)",
                 exampleURL: "/cs/colormode/5833774306689024",
                 description: i18n._("Changes the way that color values are interpreted when set by fill()/stroke()/background()."),
                 params: [
-                    i18n._("MODE: Either RGB or HSB. The default is RGB.")
+                    i18n._("MODE: Either RGB or HSB. The default is RGB."),
+                    i18n._("range (Optional): int or float: range for all color elements")
                 ]
             },
             {

--- a/js/ui/autosuggest-data.js
+++ b/js/ui/autosuggest-data.js
@@ -379,12 +379,12 @@ window.ScratchpadAutosuggestData = {
                 ]
             },
             {
-                name: "colorMode(MODE, *range)",
+                name: "colorMode(MODE, *maxValue)",
                 exampleURL: "/cs/colormode/5833774306689024",
                 description: i18n._("Changes the way that color values are interpreted when set by fill()/stroke()/background()."),
                 params: [
                     i18n._("MODE: Either RGB or HSB. The default is RGB."),
-                    i18n._("range (Optional): int or float: range for all color elements")
+                    i18n._("maxValue (Optional): number, maximum value for each color component.")
                 ]
             },
             {


### PR DESCRIPTION
The `colorMode` issue is in khan/live-editor#576.

I only edited autosuggest-data.js The other files were changed during the build process.
