### PR TITLE
Used escodegen instead of memberExpressionToString

### DIFF
--- a/build/js/live-editor.output_pjs_deps.js
+++ b/build/js/live-editor.output_pjs_deps.js
@@ -87835,23 +87835,11 @@ ASTTransforms.findResources = function (resources) {
     };
 };
 
-/**
- * Converts a MemberExpression to a String, e.g. given an AST for a.b.c will
- * return the string "a.b.c".
- */
-var memberExpressionToString = function memberExpressionToString(node) {
-    if (node.type === "Identifier") {
-        return node.name;
-    } else if (node.type === "MemberExpression") {
-        return memberExpressionToString(node.object) + "." + node.property.name;
-    }
-};
-
 ASTTransforms.rewriteNewExpressions = function (envName) {
     return {
         leave: function leave(node, path) {
             if (node.type === "NewExpression") {
-                var _name = memberExpressionToString(node.callee);
+                var _name = escodegen.generate(node.callee);
 
                 return b.CallExpression(b.CallExpression(b.MemberExpression(b.MemberExpression(b.Identifier(envName), b.Identifier("PJSOutput")), b.Identifier("applyInstance")), [node.callee, b.Literal(_name)]), node.arguments);
             }

--- a/build/js/live-editor.ui.js
+++ b/build/js/live-editor.ui.js
@@ -7,7 +7,7 @@ this["Handlebars"]["templates"]["tipbar"] = Handlebars.template(function (Handle
 function program1(depth0,data) {
   
   
-  return "x";}
+  return "&times;";}
 
 function program3(depth0,data) {
   

--- a/build/tmpl/tipbar.js
+++ b/build/tmpl/tipbar.js
@@ -7,7 +7,7 @@ this["Handlebars"]["templates"]["tipbar"] = Handlebars.template(function (Handle
 function program1(depth0,data) {
   
   
-  return "x";}
+  return "&times;";}
 
 function program3(depth0,data) {
   

--- a/js/output/pjs/pjs-ast-transforms.js
+++ b/js/output/pjs/pjs-ast-transforms.js
@@ -290,23 +290,11 @@ ASTTransforms.findResources = function(resources) {
     };
 };
 
-/**
- * Converts a MemberExpression to a String, e.g. given an AST for a.b.c will
- * return the string "a.b.c".
- */
-const memberExpressionToString = function(node) {
-    if (node.type === "Identifier") {
-        return node.name;
-    } else if (node.type === "MemberExpression") {
-        return `${memberExpressionToString(node.object)}.${node.property.name}`;
-    }
-};
-
 ASTTransforms.rewriteNewExpressions = function(envName) {
     return {
         leave(node, path) {
             if (node.type === "NewExpression") {
-                const name = memberExpressionToString(node.callee);
+                const name = escodegen.generate(node.callee);
 
                 return b.CallExpression(
                     b.CallExpression(


### PR DESCRIPTION
Removed the function `memberExpressionToString` and replaced it with
`escodegen.generate`.  The reason for this change is that escodegen
does everything `memberExpressionToString` does, but handles all node
types, which is important for some code.  See #601.