### PR TITLE
Fix live-editor in Safari 10; don't freeze the window

### DIFF
--- a/build/js/live-editor.output_pjs.js
+++ b/build/js/live-editor.output_pjs.js
@@ -2578,8 +2578,6 @@ window.PJSOutput = Backbone.View.extend({
             if (/chrome/.test(userAgent)) {
                 Object.freeze(window.location);
                 Object.freeze(window);
-            } else if (/safari/.test(userAgent)) {
-                Object.seal(window);
             } else {
                 // On other browsers only freeze if we can, on Firefox it
                 // causes an error because window is not configurable.

--- a/js/output/pjs/pjs-output.js
+++ b/js/output/pjs/pjs-output.js
@@ -109,8 +109,6 @@ window.PJSOutput = Backbone.View.extend({
             if (/chrome/.test(userAgent)) {
                 Object.freeze(window.location);
                 Object.freeze(window);
-            } else if (/safari/.test(userAgent)) {
-                Object.seal(window);
             } else {
                 // On other browsers only freeze if we can, on Firefox it
                 // causes an error because window is not configurable.


### PR DESCRIPTION
This fixes issue #606 by not trying to freeze the window in Safari. As a result, the live editor works in Safari 10 instead of throwing a TypeError.