### PR TITLE
Fix gutter tooltip line wrapping and tooltip positioning

### DIFF
--- a/css/ui/style.css
+++ b/css/ui/style.css
@@ -113,6 +113,7 @@
 /* Otherwise, the tooltip (for assertEqual) is cut off */
 .scratchpad-ace-editor .ace_tooltip {
     max-width: 550px;
+    white-space: normal; /* Allows multi-lines to wrap */
 }
 
 .scratchpad-ace-editor .ace_problem_line {

--- a/js/editors/ace/editor-ace.js
+++ b/js/editors/ace/editor-ace.js
@@ -69,6 +69,18 @@ window.AceEditor = Backbone.View.extend({
             ScratchpadAutosuggest.init(this.editor);
         }
 
+        // Override ACE gutter tooltip positioning due to bugginess
+        ace.require("ace/tooltip").Tooltip.prototype.setPosition = function (x, y) {
+            // Calculate x & y, relative to editor & scrolled window
+            var editorOffset = $(this.$parentNode).offset();
+            var xOffset = editorOffset.left - $(window).scrollLeft();
+            var yOffset = editorOffset.top - $(window).scrollTop();
+            x -= xOffset;
+            y -= yOffset;
+            this.getElement().style.left = x + "px";
+            this.getElement().style.top = y + "px";
+        };
+
         // Make the editor vertically resizable
         if (this.$el.resizable) {
             this.$el.resizable({


### PR DESCRIPTION
Background: we use our own tooltip engine for most tooltips, but we use Ace tooltips for gutter tooltips. We show the gutter tooltips for webpage warnings and for Program.assertEqual failures.

This PR fixes two issues with the gutter tooltips:
* Positioning: they are being positioned incorrectly currently, to the point of sometimes being offscreen. (See https://www.khanacademy.org/computing/computer-science/algorithms/insertion-sort/p/challenge-implement-insert ) I found multiple issues in the Ace repo about it, and implemented a fix inspired by the comment threads there.
* Line wrapping: It currently overflows for long messages, which looks bad (no background behind the overflowing text). I added a CSS property to remedy that, which seems to work well.

Screenshots of how they look now:
<img width="657" alt="screen shot 2018-06-25 at 10 57 40 am" src="https://user-images.githubusercontent.com/297042/41867449-04afcc32-7868-11e8-83f0-b01894539459.png">
<img width="748" alt="screen shot 2018-06-25 at 10 57 48 am" src="https://user-images.githubusercontent.com/297042/41867450-04d25b62-7868-11e8-8b27-4a6889134c47.png">
<img width="774" alt="screen shot 2018-06-25 at 10 57 54 am" src="https://user-images.githubusercontent.com/297042/41867452-04ec6bec-7868-11e8-92c8-3b6b16aa0d62.png">

Risks:
* I don't know if I remember every situation where we render Ace tooltips, so it's possible I've missed out on some useful manual testing. Time will tell.
* I can't easily write an automated test for this.


