### PR TITLE
Uses requestAnimationFrame to prevent frozen scripts while seeking

### DIFF
--- a/js/shared/record.js
+++ b/js/shared/record.js
@@ -198,13 +198,16 @@ window.ScratchpadRecord = Backbone.Model.extend({
             this.cacheRestore(-1 * this.seekCacheInterval);
         }
 
+        // To prevent the screen locking up while seeking ahead, processing
+        // commands, and building the cache, we can use requestAnimationFrame
+        // to process a few commands and cache entries, then see if we need to
+        // update the browser before processing another block of commands.
         let currentOffset = cacheOffset;
         const buildCache = () => {
             const animationStep = 100;
             const steps = Math.min(animationStep, seekPos - currentOffset + 1);
             const newOffset = currentOffset + steps;
 
-            // console.log(`${currentOffset} / ${newOffset} / ${seekPos}`);
             for (; currentOffset < newOffset; currentOffset += 1) {
                 this.runCommand(this.commands[currentOffset]);
                 this.cache(currentOffset);


### PR DESCRIPTION
### High-level description of change

We've had some reports about the screen locking up while seeking ahead. This is caused by processing commands and building the cache, which trap us in the single thread and prevent other behaviour.

This approach uses `window.requestAnimationFrame` to process a few commands and cache entries, then see if we need to update the browser before trying another pass.

I played with the value of `animationStep` and this seemed okay! It might make sense to show more or less though, so that would be a value to play around with. There's also some place where it's possible to generate bad cache entries if you continue to seek while it's still processing stuff. You can see this if you visit a Khan page like http://localhost:8081/computing/computer-programming/programming/drawing-basics/p/making-drawings-with-code, seek ahead to the end, and while it's processing, start scrolling around the scrollbar. That might be a problem in our Khan `webapp` though; I wasn't sure if I missed returning out of somewhere here in `live-editor` while seeking like in the `play` function, or if this is coming from the scroll bar in `webapp`.

### Are there performance implications for this change?

I haven't profiled this code, but it leads to more responsive seeking in webapp. As a result, it might be slightly slower because of the extra work.

### Have you added tests to cover this new/updated code?

No new tests, but I ran the old tests and they all passed.

### Risks involved

It's possible to mess up the cache if the seek is interrupted or the editor state is changed from outside while seeking. I don't think this solution is complete yet as a result; there's something that could still affect the result during playback.

### Are there any dependencies or blockers for merging this?

No.

### How can we verify that this change works?

My testing so far has been with the test suite here and by verifying on live examples in the Khan Academy webapp on `localhost`.