### PR TITLE
Remove visibly, replace with Page Visibility API

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,6 +22,3 @@
 [submodule "external/debugger"]
 	path = external/debugger
 	url = https://github.com/kevinb7/debugger
-[submodule "external/visibly"]
-	path = external/visibly
-	url = https://github.com/Khan/visibly.js

--- a/build-paths.json
+++ b/build-paths.json
@@ -70,8 +70,7 @@
             "js/shared/images.js",
             "js/shared/sounds.js",
             "js/shared/record.js",
-            "js/shared/config.js",
-            "external/visibly/visibly.js"
+            "js/shared/config.js"
         ],
         "output_pjs_deps": [
             "external/processing-js/processing.js",

--- a/build/external/structuredjs/structured.js
+++ b/build/external/structuredjs/structured.js
@@ -20,7 +20,7 @@
 
     if (typeof module !== "undefined" && module.exports) {
         exports = module.exports = {};
-        esprima = require("./external/esprima.js");
+        esprima = require("esprima");
         _ = require("underscore");
     } else {
         exports = this.Structured = {};
@@ -53,116 +53,6 @@
             variables: params,
             fn: callback
         };
-    }
-    
-    /*
-     * return true if n2 < n1 (according to relatively arbitrary criteria)
-     */
-    function shouldSwap(n1, n2) {
-	if (n1.type < n2.type) { //Sort by node type if different
-	    return false;
-	} else if (n1.type > n2.type) {
-	    return true;
-	} else if (n1.type === "Literal") { //Sort by value if they're literals
-	    return n1.raw > n2.raw;
-	} else { //Otherwise, loop through the properties until a difference is found and sort by that
-	    for (var k in n1) {
-		if (n1[k].hasOwnProperty("type") && n1[k] !== n2[k]) {
-		    return shouldSwap(n1[k], n2[k]);
-		}
-	    }
-	}
-    }
-    function standardizeTree(tree) {
-	if (!tree) {return tree;}
-        var r = deepClone(tree);
-        switch (tree.type) {
-            case "BinaryExpression":
-                if (_.contains(["*", "+", "===", "!==", "==", "!=", "&", "|", "^"], tree.operator)) {
-		    if (shouldSwap(tree.left, tree.right)) {
-			r.left = standardizeTree(tree.right);
-			r.right = standardizeTree(tree.left);
-            } else {
-                r.left = standardizeTree(tree.left);
-                r.right = standardizeTree(tree.right);
-            }
-		} else if (tree.operator[0] === ">") {
-		    r.operator = "<" + tree.operator.slice(1);
-		    r.left = standardizeTree(tree.right);
-		    r.right = standardizeTree(tree.left);
-		} break;
-	    case "LogicalExpression":
-	        if (_.contains(["&&", "||"], tree.operator) &&
-		    shouldSwap(tree.left, tree.right)) {
-		    r.left = standardizeTree(tree.right);
-		    r.right = standardizeTree(tree.left);
-		} break;
-	    case "AssignmentExpression":
-	        if (_.contains(["+=", "-=", "*=", "/=", "%=", "<<=", ">>=", ">>>=", "&=", "^=", "|="], tree.operator)) {
-		    var l = standardizeTree(tree.left);
-		    r = {type: "AssignmentExpression",
-			 operator: "=",
-			 left: l,
-			 right: {type: "BinaryExpression",
-				 operator: tree.operator.slice(0,-1),
-				 left: l,
-				 right: standardizeTree(tree.right)}};
-		} else {
-            r.left = standardizeTree(r.left);
-            r.right = standardizeTree(r.right);
-        } break;
-	    case "UpdateExpression":
-	        if (_.contains(["++", "--"], tree.operator)) {
-		    var l = standardizeTree(tree.argument);
-		    r = {type: "AssignmentExpression",
-			 operator: "=",
-			 left: l,
-			 right: {type: "BinaryExpression",
-				 operator: tree.operator[0],
-				 left: l,
-				 right: {type: "Literal",
-					 value: 1,
-					 raw: "1"}}};
-		} break;
-	    case "VariableDeclaration":
-	        if (tree.kind === "var") {
-		    r = [deepClone(tree)];
-		    for (var i in tree.declarations) {
-			if (tree.declarations[i].type === "VariableDeclarator" &&
-			    tree.declarations[i].init !== null) {
-			    r.push({type: "ExpressionStatement",
-				    expression: {type: "AssignmentExpression",
-						 operator: "=",
-						 left: tree.declarations[i].id,
-						 right: standardizeTree(tree.declarations[i].init)}});
-			    r[0].declarations[i].init = null;
-			}
-		    }
-		} break;
-        case "Literal":
-            r.raw = tree.raw
-                .replace(/^(?:\"(.*?)\"|\'(.*?)\')$/, function(match, p1, p2) {
-                    return "\"" + ((p1 || "") + (p2 || ""))
-                        .replace(/"|'/g, "\"") + "\"";
-                });
-            console.log(r.raw); break;
-	    default:
-	        for (var key in tree) {
-		    if (!tree.hasOwnProperty(key) || !_.isObject(tree[key])) {
-			continue;
-		    }
-		    if (_.isArray(tree[key])) {
-			var ar = [];
-			for (var i in tree[key]) {  /* jshint forin:false */
-			    ar = ar.concat(standardizeTree(tree[key][i]));
-			}
-			r[key] = ar;
-		    } else {
-			r[key] = standardizeTree(tree[key]);
-		    }
-		}
-        }
-        return r;
     }
 
     /*
@@ -274,7 +164,6 @@
             _: [],
             vars: {}
         };
-	codeTree = standardizeTree(codeTree);
         if (wildcardVars.order.length === 0 || options.single) {
             // With no vars to match, our normal greedy approach works great.
             result = checkMatchTree(codeTree, toFind, peers, wildcardVars, matchResult, options);
@@ -389,7 +278,7 @@
     function checkUserVarCallbacks(wVars, varCallbacks) {
         // Clear old failure message if needed
         delete originalVarCallbacks.failure;
-        for (var key in varCallbacks) {  /* jshint forin:false */
+        for (var key in varCallbacks) {
             // Property strings may be "$foo, $bar, $baz" to mimic arrays.
             var varNames = varCallbacks[key].variables;
             var varValues = _.map(varNames, function(varName) {
@@ -463,7 +352,7 @@
      *        relative ordering matter).
      */
     function parseStructureWithVars(structure, wVars) {
-        var tree = standardizeTree(parseStructure(structure));
+        var tree = parseStructure(structure);
         foldConstants(tree);
         simplifyTree(tree, wVars);
         return tree;
@@ -473,7 +362,7 @@
      * Constant folds the syntax tree
      */
     function foldConstants(tree) {
-        for (var key in tree) {  /* jshint forin:false */
+        for (var key in tree) {
             if (!tree.hasOwnProperty(key)) {
                 continue; // Inherited property
             }
@@ -487,7 +376,6 @@
                  * This is easy to extend, but it means we lose the ability to match
                  * potentially useful expressions like 5 + 5 with a pattern like _ + _.
                  */
-                /* jshint eqeqeq:false */
                 if (ast.type == esprima.Syntax.UnaryExpression) {
                     var argument = ast.argument;
                     if (argument.type === esprima.Syntax.Literal &&
@@ -527,7 +415,7 @@
      *
      */
     function simplifyTree(tree, wVars) {
-        for (var key in tree) {  /* jshint forin:false */
+        for (var key in tree) {
             if (!tree.hasOwnProperty(key)) {
                 continue; // Inherited property
             }
@@ -589,14 +477,12 @@
      * toFind: The syntax node from the structure that we wish to find.
      * peersToFind: The remaining ordered syntax nodes that we must find after
      *     toFind (and on the same level as toFind).
-     * modify: should it call RestructureTree()?
      */
     function checkMatchTree(currTree, toFind, peersToFind, wVars, matchResults, options) {
         if (_.isArray(toFind)) {
             console.error("toFind should never be an array.");
             console.error(toFind);
         }
-        /* jshint -W041, -W116 */
         if (currTree == undefined) {
             if (toFind == undefined) {
                 matchResults._.push(currTree);
@@ -613,15 +499,15 @@
             return false;
         }
         // Check children.
-        for (var key in currTree) {  /* jshint forin:false */
+        for (var key in currTree) {
             if (!currTree.hasOwnProperty(key) || !_.isObject(currTree[key])) {
                 continue; // Skip inherited properties
             }
             // Recursively check for matches
             if ((_.isArray(currTree[key]) &&
-                    checkNodeArray(currTree[key], toFind, peersToFind, wVars, matchResults, options, true)) ||
+                    checkNodeArray(currTree[key], toFind, peersToFind, wVars, matchResults, options)) ||
                 (!_.isArray(currTree[key]) &&
-                    checkMatchTree(currTree[key], toFind, peersToFind, wVars, matchResults, options, true))) {
+                    checkMatchTree(currTree[key], toFind, peersToFind, wVars, matchResults, options))) {
                 return matchResults;
             }
         }
@@ -778,7 +664,7 @@
             rootToSet = currNode;
         }
 
-        for (var key in toFind) {  /* jshint forin:false */
+        for (var key in toFind) {
             // Ignore inherited properties; also, null properties can be
             // anything and do not have to exist.
             if (!toFind.hasOwnProperty(key) || toFind[key] === null) {
@@ -788,7 +674,6 @@
             var subCurr = currNode[key];
             // Undefined properties can be anything, but they must exist.
             if (subFind === undefined) {
-                /* jshint -W116 */
                 if (subCurr == undefined) {
                     return false;
                 } else {
@@ -1009,7 +894,7 @@
             return node;
         }
 
-        for (var prop in node) {  /* jshint forin:false */
+        for (var prop in node) {
             if (!node.hasOwnProperty(prop)) {
                 continue;
             }

--- a/build/external/structuredjs/structured.js
+++ b/build/external/structuredjs/structured.js
@@ -20,7 +20,7 @@
 
     if (typeof module !== "undefined" && module.exports) {
         exports = module.exports = {};
-        esprima = require("esprima");
+        esprima = require("./external/esprima.js");
         _ = require("underscore");
     } else {
         exports = this.Structured = {};
@@ -53,6 +53,116 @@
             variables: params,
             fn: callback
         };
+    }
+    
+    /*
+     * return true if n2 < n1 (according to relatively arbitrary criteria)
+     */
+    function shouldSwap(n1, n2) {
+	if (n1.type < n2.type) { //Sort by node type if different
+	    return false;
+	} else if (n1.type > n2.type) {
+	    return true;
+	} else if (n1.type === "Literal") { //Sort by value if they're literals
+	    return n1.raw > n2.raw;
+	} else { //Otherwise, loop through the properties until a difference is found and sort by that
+	    for (var k in n1) {
+		if (n1[k].hasOwnProperty("type") && n1[k] !== n2[k]) {
+		    return shouldSwap(n1[k], n2[k]);
+		}
+	    }
+	}
+    }
+    function standardizeTree(tree) {
+	if (!tree) {return tree;}
+        var r = deepClone(tree);
+        switch (tree.type) {
+            case "BinaryExpression":
+                if (_.contains(["*", "+", "===", "!==", "==", "!=", "&", "|", "^"], tree.operator)) {
+		    if (shouldSwap(tree.left, tree.right)) {
+			r.left = standardizeTree(tree.right);
+			r.right = standardizeTree(tree.left);
+            } else {
+                r.left = standardizeTree(tree.left);
+                r.right = standardizeTree(tree.right);
+            }
+		} else if (tree.operator[0] === ">") {
+		    r.operator = "<" + tree.operator.slice(1);
+		    r.left = standardizeTree(tree.right);
+		    r.right = standardizeTree(tree.left);
+		} break;
+	    case "LogicalExpression":
+	        if (_.contains(["&&", "||"], tree.operator) &&
+		    shouldSwap(tree.left, tree.right)) {
+		    r.left = standardizeTree(tree.right);
+		    r.right = standardizeTree(tree.left);
+		} break;
+	    case "AssignmentExpression":
+	        if (_.contains(["+=", "-=", "*=", "/=", "%=", "<<=", ">>=", ">>>=", "&=", "^=", "|="], tree.operator)) {
+		    var l = standardizeTree(tree.left);
+		    r = {type: "AssignmentExpression",
+			 operator: "=",
+			 left: l,
+			 right: {type: "BinaryExpression",
+				 operator: tree.operator.slice(0,-1),
+				 left: l,
+				 right: standardizeTree(tree.right)}};
+		} else {
+            r.left = standardizeTree(r.left);
+            r.right = standardizeTree(r.right);
+        } break;
+	    case "UpdateExpression":
+	        if (_.contains(["++", "--"], tree.operator)) {
+		    var l = standardizeTree(tree.argument);
+		    r = {type: "AssignmentExpression",
+			 operator: "=",
+			 left: l,
+			 right: {type: "BinaryExpression",
+				 operator: tree.operator[0],
+				 left: l,
+				 right: {type: "Literal",
+					 value: 1,
+					 raw: "1"}}};
+		} break;
+	    case "VariableDeclaration":
+	        if (tree.kind === "var") {
+		    r = [deepClone(tree)];
+		    for (var i in tree.declarations) {
+			if (tree.declarations[i].type === "VariableDeclarator" &&
+			    tree.declarations[i].init !== null) {
+			    r.push({type: "ExpressionStatement",
+				    expression: {type: "AssignmentExpression",
+						 operator: "=",
+						 left: tree.declarations[i].id,
+						 right: standardizeTree(tree.declarations[i].init)}});
+			    r[0].declarations[i].init = null;
+			}
+		    }
+		} break;
+            case "Literal":
+                r.raw = tree.raw
+                    .replace(/^(?:\"(.*?)\"|\'(.*?)\')$/, function(match, p1, p2) {
+                        return "\"" + ((p1 || "") + (p2 || ""))
+                            .replace(/"|'/g, "\"") + "\"";
+                    });
+                break;
+	    default:
+	        for (var key in tree) {
+		    if (!tree.hasOwnProperty(key) || !_.isObject(tree[key])) {
+			continue;
+		    }
+		    if (_.isArray(tree[key])) {
+			var ar = [];
+			for (var i in tree[key]) {  /* jshint forin:false */
+			    ar = ar.concat(standardizeTree(tree[key][i]));
+			}
+			r[key] = ar;
+		    } else {
+			r[key] = standardizeTree(tree[key]);
+		    }
+		}
+        }
+        return r;
     }
 
     /*
@@ -164,6 +274,7 @@
             _: [],
             vars: {}
         };
+	codeTree = standardizeTree(codeTree);
         if (wildcardVars.order.length === 0 || options.single) {
             // With no vars to match, our normal greedy approach works great.
             result = checkMatchTree(codeTree, toFind, peers, wildcardVars, matchResult, options);
@@ -278,7 +389,7 @@
     function checkUserVarCallbacks(wVars, varCallbacks) {
         // Clear old failure message if needed
         delete originalVarCallbacks.failure;
-        for (var key in varCallbacks) {
+        for (var key in varCallbacks) {  /* jshint forin:false */
             // Property strings may be "$foo, $bar, $baz" to mimic arrays.
             var varNames = varCallbacks[key].variables;
             var varValues = _.map(varNames, function(varName) {
@@ -352,7 +463,7 @@
      *        relative ordering matter).
      */
     function parseStructureWithVars(structure, wVars) {
-        var tree = parseStructure(structure);
+        var tree = standardizeTree(parseStructure(structure));
         foldConstants(tree);
         simplifyTree(tree, wVars);
         return tree;
@@ -362,7 +473,7 @@
      * Constant folds the syntax tree
      */
     function foldConstants(tree) {
-        for (var key in tree) {
+        for (var key in tree) {  /* jshint forin:false */
             if (!tree.hasOwnProperty(key)) {
                 continue; // Inherited property
             }
@@ -376,6 +487,7 @@
                  * This is easy to extend, but it means we lose the ability to match
                  * potentially useful expressions like 5 + 5 with a pattern like _ + _.
                  */
+                /* jshint eqeqeq:false */
                 if (ast.type == esprima.Syntax.UnaryExpression) {
                     var argument = ast.argument;
                     if (argument.type === esprima.Syntax.Literal &&
@@ -415,7 +527,7 @@
      *
      */
     function simplifyTree(tree, wVars) {
-        for (var key in tree) {
+        for (var key in tree) {  /* jshint forin:false */
             if (!tree.hasOwnProperty(key)) {
                 continue; // Inherited property
             }
@@ -477,12 +589,14 @@
      * toFind: The syntax node from the structure that we wish to find.
      * peersToFind: The remaining ordered syntax nodes that we must find after
      *     toFind (and on the same level as toFind).
+     * modify: should it call RestructureTree()?
      */
     function checkMatchTree(currTree, toFind, peersToFind, wVars, matchResults, options) {
         if (_.isArray(toFind)) {
             console.error("toFind should never be an array.");
             console.error(toFind);
         }
+        /* jshint -W041, -W116 */
         if (currTree == undefined) {
             if (toFind == undefined) {
                 matchResults._.push(currTree);
@@ -499,15 +613,15 @@
             return false;
         }
         // Check children.
-        for (var key in currTree) {
+        for (var key in currTree) {  /* jshint forin:false */
             if (!currTree.hasOwnProperty(key) || !_.isObject(currTree[key])) {
                 continue; // Skip inherited properties
             }
             // Recursively check for matches
             if ((_.isArray(currTree[key]) &&
-                    checkNodeArray(currTree[key], toFind, peersToFind, wVars, matchResults, options)) ||
+                    checkNodeArray(currTree[key], toFind, peersToFind, wVars, matchResults, options, true)) ||
                 (!_.isArray(currTree[key]) &&
-                    checkMatchTree(currTree[key], toFind, peersToFind, wVars, matchResults, options))) {
+                    checkMatchTree(currTree[key], toFind, peersToFind, wVars, matchResults, options, true))) {
                 return matchResults;
             }
         }
@@ -664,7 +778,7 @@
             rootToSet = currNode;
         }
 
-        for (var key in toFind) {
+        for (var key in toFind) {  /* jshint forin:false */
             // Ignore inherited properties; also, null properties can be
             // anything and do not have to exist.
             if (!toFind.hasOwnProperty(key) || toFind[key] === null) {
@@ -674,6 +788,7 @@
             var subCurr = currNode[key];
             // Undefined properties can be anything, but they must exist.
             if (subFind === undefined) {
+                /* jshint -W116 */
                 if (subCurr == undefined) {
                     return false;
                 } else {
@@ -894,7 +1009,7 @@
             return node;
         }
 
-        for (var prop in node) {
+        for (var prop in node) {  /* jshint forin:false */
             if (!node.hasOwnProperty(prop)) {
                 continue;
             }

--- a/build/external/structuredjs/structured.js
+++ b/build/external/structuredjs/structured.js
@@ -139,13 +139,13 @@
 			}
 		    }
 		} break;
-            case "Literal":
-                r.raw = tree.raw
-                    .replace(/^(?:\"(.*?)\"|\'(.*?)\')$/, function(match, p1, p2) {
-                        return "\"" + ((p1 || "") + (p2 || ""))
-                            .replace(/"|'/g, "\"") + "\"";
-                    });
-                break;
+        case "Literal":
+            r.raw = tree.raw
+                .replace(/^(?:\"(.*?)\"|\'(.*?)\')$/, function(match, p1, p2) {
+                    return "\"" + ((p1 || "") + (p2 || ""))
+                        .replace(/"|'/g, "\"") + "\"";
+                });
+            console.log(r.raw); break;
 	    default:
 	        for (var key in tree) {
 		    if (!tree.hasOwnProperty(key) || !_.isObject(tree[key])) {

--- a/build/js/live-editor.editor_structured_blocks_deps.js
+++ b/build/js/live-editor.editor_structured_blocks_deps.js
@@ -3770,7 +3770,7 @@ parseStatement: true, parseSourceElement: true */
 
     if (typeof module !== "undefined" && module.exports) {
         exports = module.exports = {};
-        esprima = require("esprima");
+        esprima = require("./external/esprima.js");
         _ = require("underscore");
     } else {
         exports = this.Structured = {};
@@ -3803,6 +3803,116 @@ parseStatement: true, parseSourceElement: true */
             variables: params,
             fn: callback
         };
+    }
+    
+    /*
+     * return true if n2 < n1 (according to relatively arbitrary criteria)
+     */
+    function shouldSwap(n1, n2) {
+	if (n1.type < n2.type) { //Sort by node type if different
+	    return false;
+	} else if (n1.type > n2.type) {
+	    return true;
+	} else if (n1.type === "Literal") { //Sort by value if they're literals
+	    return n1.raw > n2.raw;
+	} else { //Otherwise, loop through the properties until a difference is found and sort by that
+	    for (var k in n1) {
+		if (n1[k].hasOwnProperty("type") && n1[k] !== n2[k]) {
+		    return shouldSwap(n1[k], n2[k]);
+		}
+	    }
+	}
+    }
+    function standardizeTree(tree) {
+	if (!tree) {return tree;}
+        var r = deepClone(tree);
+        switch (tree.type) {
+            case "BinaryExpression":
+                if (_.contains(["*", "+", "===", "!==", "==", "!=", "&", "|", "^"], tree.operator)) {
+		    if (shouldSwap(tree.left, tree.right)) {
+			r.left = standardizeTree(tree.right);
+			r.right = standardizeTree(tree.left);
+            } else {
+                r.left = standardizeTree(tree.left);
+                r.right = standardizeTree(tree.right);
+            }
+		} else if (tree.operator[0] === ">") {
+		    r.operator = "<" + tree.operator.slice(1);
+		    r.left = standardizeTree(tree.right);
+		    r.right = standardizeTree(tree.left);
+		} break;
+	    case "LogicalExpression":
+	        if (_.contains(["&&", "||"], tree.operator) &&
+		    shouldSwap(tree.left, tree.right)) {
+		    r.left = standardizeTree(tree.right);
+		    r.right = standardizeTree(tree.left);
+		} break;
+	    case "AssignmentExpression":
+	        if (_.contains(["+=", "-=", "*=", "/=", "%=", "<<=", ">>=", ">>>=", "&=", "^=", "|="], tree.operator)) {
+		    var l = standardizeTree(tree.left);
+		    r = {type: "AssignmentExpression",
+			 operator: "=",
+			 left: l,
+			 right: {type: "BinaryExpression",
+				 operator: tree.operator.slice(0,-1),
+				 left: l,
+				 right: standardizeTree(tree.right)}};
+		} else {
+            r.left = standardizeTree(r.left);
+            r.right = standardizeTree(r.right);
+        } break;
+	    case "UpdateExpression":
+	        if (_.contains(["++", "--"], tree.operator)) {
+		    var l = standardizeTree(tree.argument);
+		    r = {type: "AssignmentExpression",
+			 operator: "=",
+			 left: l,
+			 right: {type: "BinaryExpression",
+				 operator: tree.operator[0],
+				 left: l,
+				 right: {type: "Literal",
+					 value: 1,
+					 raw: "1"}}};
+		} break;
+	    case "VariableDeclaration":
+	        if (tree.kind === "var") {
+		    r = [deepClone(tree)];
+		    for (var i in tree.declarations) {
+			if (tree.declarations[i].type === "VariableDeclarator" &&
+			    tree.declarations[i].init !== null) {
+			    r.push({type: "ExpressionStatement",
+				    expression: {type: "AssignmentExpression",
+						 operator: "=",
+						 left: tree.declarations[i].id,
+						 right: standardizeTree(tree.declarations[i].init)}});
+			    r[0].declarations[i].init = null;
+			}
+		    }
+		} break;
+            case "Literal":
+                r.raw = tree.raw
+                    .replace(/^(?:\"(.*?)\"|\'(.*?)\')$/, function(match, p1, p2) {
+                        return "\"" + ((p1 || "") + (p2 || ""))
+                            .replace(/"|'/g, "\"") + "\"";
+                    });
+                break;
+	    default:
+	        for (var key in tree) {
+		    if (!tree.hasOwnProperty(key) || !_.isObject(tree[key])) {
+			continue;
+		    }
+		    if (_.isArray(tree[key])) {
+			var ar = [];
+			for (var i in tree[key]) {  /* jshint forin:false */
+			    ar = ar.concat(standardizeTree(tree[key][i]));
+			}
+			r[key] = ar;
+		    } else {
+			r[key] = standardizeTree(tree[key]);
+		    }
+		}
+        }
+        return r;
     }
 
     /*
@@ -3914,6 +4024,7 @@ parseStatement: true, parseSourceElement: true */
             _: [],
             vars: {}
         };
+	codeTree = standardizeTree(codeTree);
         if (wildcardVars.order.length === 0 || options.single) {
             // With no vars to match, our normal greedy approach works great.
             result = checkMatchTree(codeTree, toFind, peers, wildcardVars, matchResult, options);
@@ -4028,7 +4139,7 @@ parseStatement: true, parseSourceElement: true */
     function checkUserVarCallbacks(wVars, varCallbacks) {
         // Clear old failure message if needed
         delete originalVarCallbacks.failure;
-        for (var key in varCallbacks) {
+        for (var key in varCallbacks) {  /* jshint forin:false */
             // Property strings may be "$foo, $bar, $baz" to mimic arrays.
             var varNames = varCallbacks[key].variables;
             var varValues = _.map(varNames, function(varName) {
@@ -4102,7 +4213,7 @@ parseStatement: true, parseSourceElement: true */
      *        relative ordering matter).
      */
     function parseStructureWithVars(structure, wVars) {
-        var tree = parseStructure(structure);
+        var tree = standardizeTree(parseStructure(structure));
         foldConstants(tree);
         simplifyTree(tree, wVars);
         return tree;
@@ -4112,7 +4223,7 @@ parseStatement: true, parseSourceElement: true */
      * Constant folds the syntax tree
      */
     function foldConstants(tree) {
-        for (var key in tree) {
+        for (var key in tree) {  /* jshint forin:false */
             if (!tree.hasOwnProperty(key)) {
                 continue; // Inherited property
             }
@@ -4126,6 +4237,7 @@ parseStatement: true, parseSourceElement: true */
                  * This is easy to extend, but it means we lose the ability to match
                  * potentially useful expressions like 5 + 5 with a pattern like _ + _.
                  */
+                /* jshint eqeqeq:false */
                 if (ast.type == esprima.Syntax.UnaryExpression) {
                     var argument = ast.argument;
                     if (argument.type === esprima.Syntax.Literal &&
@@ -4165,7 +4277,7 @@ parseStatement: true, parseSourceElement: true */
      *
      */
     function simplifyTree(tree, wVars) {
-        for (var key in tree) {
+        for (var key in tree) {  /* jshint forin:false */
             if (!tree.hasOwnProperty(key)) {
                 continue; // Inherited property
             }
@@ -4227,12 +4339,14 @@ parseStatement: true, parseSourceElement: true */
      * toFind: The syntax node from the structure that we wish to find.
      * peersToFind: The remaining ordered syntax nodes that we must find after
      *     toFind (and on the same level as toFind).
+     * modify: should it call RestructureTree()?
      */
     function checkMatchTree(currTree, toFind, peersToFind, wVars, matchResults, options) {
         if (_.isArray(toFind)) {
             console.error("toFind should never be an array.");
             console.error(toFind);
         }
+        /* jshint -W041, -W116 */
         if (currTree == undefined) {
             if (toFind == undefined) {
                 matchResults._.push(currTree);
@@ -4249,15 +4363,15 @@ parseStatement: true, parseSourceElement: true */
             return false;
         }
         // Check children.
-        for (var key in currTree) {
+        for (var key in currTree) {  /* jshint forin:false */
             if (!currTree.hasOwnProperty(key) || !_.isObject(currTree[key])) {
                 continue; // Skip inherited properties
             }
             // Recursively check for matches
             if ((_.isArray(currTree[key]) &&
-                    checkNodeArray(currTree[key], toFind, peersToFind, wVars, matchResults, options)) ||
+                    checkNodeArray(currTree[key], toFind, peersToFind, wVars, matchResults, options, true)) ||
                 (!_.isArray(currTree[key]) &&
-                    checkMatchTree(currTree[key], toFind, peersToFind, wVars, matchResults, options))) {
+                    checkMatchTree(currTree[key], toFind, peersToFind, wVars, matchResults, options, true))) {
                 return matchResults;
             }
         }
@@ -4414,7 +4528,7 @@ parseStatement: true, parseSourceElement: true */
             rootToSet = currNode;
         }
 
-        for (var key in toFind) {
+        for (var key in toFind) {  /* jshint forin:false */
             // Ignore inherited properties; also, null properties can be
             // anything and do not have to exist.
             if (!toFind.hasOwnProperty(key) || toFind[key] === null) {
@@ -4424,6 +4538,7 @@ parseStatement: true, parseSourceElement: true */
             var subCurr = currNode[key];
             // Undefined properties can be anything, but they must exist.
             if (subFind === undefined) {
+                /* jshint -W116 */
                 if (subCurr == undefined) {
                     return false;
                 } else {
@@ -4644,7 +4759,7 @@ parseStatement: true, parseSourceElement: true */
             return node;
         }
 
-        for (var prop in node) {
+        for (var prop in node) {  /* jshint forin:false */
             if (!node.hasOwnProperty(prop)) {
                 continue;
             }

--- a/build/js/live-editor.editor_structured_blocks_deps.js
+++ b/build/js/live-editor.editor_structured_blocks_deps.js
@@ -3889,13 +3889,13 @@ parseStatement: true, parseSourceElement: true */
 			}
 		    }
 		} break;
-            case "Literal":
-                r.raw = tree.raw
-                    .replace(/^(?:\"(.*?)\"|\'(.*?)\')$/, function(match, p1, p2) {
-                        return "\"" + ((p1 || "") + (p2 || ""))
-                            .replace(/"|'/g, "\"") + "\"";
-                    });
-                break;
+        case "Literal":
+            r.raw = tree.raw
+                .replace(/^(?:\"(.*?)\"|\'(.*?)\')$/, function(match, p1, p2) {
+                    return "\"" + ((p1 || "") + (p2 || ""))
+                        .replace(/"|'/g, "\"") + "\"";
+                });
+            console.log(r.raw); break;
 	    default:
 	        for (var key in tree) {
 		    if (!tree.hasOwnProperty(key) || !_.isObject(tree[key])) {

--- a/build/js/live-editor.editor_structured_blocks_deps.js
+++ b/build/js/live-editor.editor_structured_blocks_deps.js
@@ -3770,7 +3770,7 @@ parseStatement: true, parseSourceElement: true */
 
     if (typeof module !== "undefined" && module.exports) {
         exports = module.exports = {};
-        esprima = require("./external/esprima.js");
+        esprima = require("esprima");
         _ = require("underscore");
     } else {
         exports = this.Structured = {};
@@ -3803,116 +3803,6 @@ parseStatement: true, parseSourceElement: true */
             variables: params,
             fn: callback
         };
-    }
-    
-    /*
-     * return true if n2 < n1 (according to relatively arbitrary criteria)
-     */
-    function shouldSwap(n1, n2) {
-	if (n1.type < n2.type) { //Sort by node type if different
-	    return false;
-	} else if (n1.type > n2.type) {
-	    return true;
-	} else if (n1.type === "Literal") { //Sort by value if they're literals
-	    return n1.raw > n2.raw;
-	} else { //Otherwise, loop through the properties until a difference is found and sort by that
-	    for (var k in n1) {
-		if (n1[k].hasOwnProperty("type") && n1[k] !== n2[k]) {
-		    return shouldSwap(n1[k], n2[k]);
-		}
-	    }
-	}
-    }
-    function standardizeTree(tree) {
-	if (!tree) {return tree;}
-        var r = deepClone(tree);
-        switch (tree.type) {
-            case "BinaryExpression":
-                if (_.contains(["*", "+", "===", "!==", "==", "!=", "&", "|", "^"], tree.operator)) {
-		    if (shouldSwap(tree.left, tree.right)) {
-			r.left = standardizeTree(tree.right);
-			r.right = standardizeTree(tree.left);
-            } else {
-                r.left = standardizeTree(tree.left);
-                r.right = standardizeTree(tree.right);
-            }
-		} else if (tree.operator[0] === ">") {
-		    r.operator = "<" + tree.operator.slice(1);
-		    r.left = standardizeTree(tree.right);
-		    r.right = standardizeTree(tree.left);
-		} break;
-	    case "LogicalExpression":
-	        if (_.contains(["&&", "||"], tree.operator) &&
-		    shouldSwap(tree.left, tree.right)) {
-		    r.left = standardizeTree(tree.right);
-		    r.right = standardizeTree(tree.left);
-		} break;
-	    case "AssignmentExpression":
-	        if (_.contains(["+=", "-=", "*=", "/=", "%=", "<<=", ">>=", ">>>=", "&=", "^=", "|="], tree.operator)) {
-		    var l = standardizeTree(tree.left);
-		    r = {type: "AssignmentExpression",
-			 operator: "=",
-			 left: l,
-			 right: {type: "BinaryExpression",
-				 operator: tree.operator.slice(0,-1),
-				 left: l,
-				 right: standardizeTree(tree.right)}};
-		} else {
-            r.left = standardizeTree(r.left);
-            r.right = standardizeTree(r.right);
-        } break;
-	    case "UpdateExpression":
-	        if (_.contains(["++", "--"], tree.operator)) {
-		    var l = standardizeTree(tree.argument);
-		    r = {type: "AssignmentExpression",
-			 operator: "=",
-			 left: l,
-			 right: {type: "BinaryExpression",
-				 operator: tree.operator[0],
-				 left: l,
-				 right: {type: "Literal",
-					 value: 1,
-					 raw: "1"}}};
-		} break;
-	    case "VariableDeclaration":
-	        if (tree.kind === "var") {
-		    r = [deepClone(tree)];
-		    for (var i in tree.declarations) {
-			if (tree.declarations[i].type === "VariableDeclarator" &&
-			    tree.declarations[i].init !== null) {
-			    r.push({type: "ExpressionStatement",
-				    expression: {type: "AssignmentExpression",
-						 operator: "=",
-						 left: tree.declarations[i].id,
-						 right: standardizeTree(tree.declarations[i].init)}});
-			    r[0].declarations[i].init = null;
-			}
-		    }
-		} break;
-        case "Literal":
-            r.raw = tree.raw
-                .replace(/^(?:\"(.*?)\"|\'(.*?)\')$/, function(match, p1, p2) {
-                    return "\"" + ((p1 || "") + (p2 || ""))
-                        .replace(/"|'/g, "\"") + "\"";
-                });
-            console.log(r.raw); break;
-	    default:
-	        for (var key in tree) {
-		    if (!tree.hasOwnProperty(key) || !_.isObject(tree[key])) {
-			continue;
-		    }
-		    if (_.isArray(tree[key])) {
-			var ar = [];
-			for (var i in tree[key]) {  /* jshint forin:false */
-			    ar = ar.concat(standardizeTree(tree[key][i]));
-			}
-			r[key] = ar;
-		    } else {
-			r[key] = standardizeTree(tree[key]);
-		    }
-		}
-        }
-        return r;
     }
 
     /*
@@ -4024,7 +3914,6 @@ parseStatement: true, parseSourceElement: true */
             _: [],
             vars: {}
         };
-	codeTree = standardizeTree(codeTree);
         if (wildcardVars.order.length === 0 || options.single) {
             // With no vars to match, our normal greedy approach works great.
             result = checkMatchTree(codeTree, toFind, peers, wildcardVars, matchResult, options);
@@ -4139,7 +4028,7 @@ parseStatement: true, parseSourceElement: true */
     function checkUserVarCallbacks(wVars, varCallbacks) {
         // Clear old failure message if needed
         delete originalVarCallbacks.failure;
-        for (var key in varCallbacks) {  /* jshint forin:false */
+        for (var key in varCallbacks) {
             // Property strings may be "$foo, $bar, $baz" to mimic arrays.
             var varNames = varCallbacks[key].variables;
             var varValues = _.map(varNames, function(varName) {
@@ -4213,7 +4102,7 @@ parseStatement: true, parseSourceElement: true */
      *        relative ordering matter).
      */
     function parseStructureWithVars(structure, wVars) {
-        var tree = standardizeTree(parseStructure(structure));
+        var tree = parseStructure(structure);
         foldConstants(tree);
         simplifyTree(tree, wVars);
         return tree;
@@ -4223,7 +4112,7 @@ parseStatement: true, parseSourceElement: true */
      * Constant folds the syntax tree
      */
     function foldConstants(tree) {
-        for (var key in tree) {  /* jshint forin:false */
+        for (var key in tree) {
             if (!tree.hasOwnProperty(key)) {
                 continue; // Inherited property
             }
@@ -4237,7 +4126,6 @@ parseStatement: true, parseSourceElement: true */
                  * This is easy to extend, but it means we lose the ability to match
                  * potentially useful expressions like 5 + 5 with a pattern like _ + _.
                  */
-                /* jshint eqeqeq:false */
                 if (ast.type == esprima.Syntax.UnaryExpression) {
                     var argument = ast.argument;
                     if (argument.type === esprima.Syntax.Literal &&
@@ -4277,7 +4165,7 @@ parseStatement: true, parseSourceElement: true */
      *
      */
     function simplifyTree(tree, wVars) {
-        for (var key in tree) {  /* jshint forin:false */
+        for (var key in tree) {
             if (!tree.hasOwnProperty(key)) {
                 continue; // Inherited property
             }
@@ -4339,14 +4227,12 @@ parseStatement: true, parseSourceElement: true */
      * toFind: The syntax node from the structure that we wish to find.
      * peersToFind: The remaining ordered syntax nodes that we must find after
      *     toFind (and on the same level as toFind).
-     * modify: should it call RestructureTree()?
      */
     function checkMatchTree(currTree, toFind, peersToFind, wVars, matchResults, options) {
         if (_.isArray(toFind)) {
             console.error("toFind should never be an array.");
             console.error(toFind);
         }
-        /* jshint -W041, -W116 */
         if (currTree == undefined) {
             if (toFind == undefined) {
                 matchResults._.push(currTree);
@@ -4363,15 +4249,15 @@ parseStatement: true, parseSourceElement: true */
             return false;
         }
         // Check children.
-        for (var key in currTree) {  /* jshint forin:false */
+        for (var key in currTree) {
             if (!currTree.hasOwnProperty(key) || !_.isObject(currTree[key])) {
                 continue; // Skip inherited properties
             }
             // Recursively check for matches
             if ((_.isArray(currTree[key]) &&
-                    checkNodeArray(currTree[key], toFind, peersToFind, wVars, matchResults, options, true)) ||
+                    checkNodeArray(currTree[key], toFind, peersToFind, wVars, matchResults, options)) ||
                 (!_.isArray(currTree[key]) &&
-                    checkMatchTree(currTree[key], toFind, peersToFind, wVars, matchResults, options, true))) {
+                    checkMatchTree(currTree[key], toFind, peersToFind, wVars, matchResults, options))) {
                 return matchResults;
             }
         }
@@ -4528,7 +4414,7 @@ parseStatement: true, parseSourceElement: true */
             rootToSet = currNode;
         }
 
-        for (var key in toFind) {  /* jshint forin:false */
+        for (var key in toFind) {
             // Ignore inherited properties; also, null properties can be
             // anything and do not have to exist.
             if (!toFind.hasOwnProperty(key) || toFind[key] === null) {
@@ -4538,7 +4424,6 @@ parseStatement: true, parseSourceElement: true */
             var subCurr = currNode[key];
             // Undefined properties can be anything, but they must exist.
             if (subFind === undefined) {
-                /* jshint -W116 */
                 if (subCurr == undefined) {
                     return false;
                 } else {
@@ -4759,7 +4644,7 @@ parseStatement: true, parseSourceElement: true */
             return node;
         }
 
-        for (var prop in node) {  /* jshint forin:false */
+        for (var prop in node) {
             if (!node.hasOwnProperty(prop)) {
                 continue;
             }

--- a/build/js/live-editor.output_pjs_deps.js
+++ b/build/js/live-editor.output_pjs_deps.js
@@ -87417,8 +87417,6 @@ window.walkAST = function (node, path, visitors) {
  * @constructor
  */
 window.LoopProtector = function (callback, timeouts, reportLocation) {
-    var _this = this;
-
     this.callback = callback || function () {};
     this.timeout = 200;
     this.branchStartTime = 0;
@@ -87435,14 +87433,14 @@ window.LoopProtector = function (callback, timeouts, reportLocation) {
     this.KAInfiniteLoopProtect = this._KAInfiniteLoopProtect.bind(this);
     this.KAInfiniteLoopSetTimeout = this._KAInfiniteLoopSetTimeout.bind(this);
 
-    document.addEventListener("visibilitychange", function () {
+    document.addEventListener("visibilitychange", (function () {
         if (document.hidden) {
-            _this.visible = true;
-            _this.branchStartTime = 0;
+            this.visible = true;
+            this.branchStartTime = 0;
         } else {
-            _this.visible = false;
+            this.visible = false;
         }
-    });
+    }).bind(this));
 
     this.visible = !document.hidden;
 };
@@ -87464,7 +87462,7 @@ window.LoopProtector.prototype = {
      * @private
      */
     _KAInfiniteLoopProtect: function _KAInfiniteLoopProtect(location) {
-        var _this2 = this;
+        var _this = this;
 
         if (location) {
             if (!this.loopCounts[location]) {
@@ -87481,9 +87479,9 @@ window.LoopProtector.prototype = {
         } else if (now - this.branchStartTime > this.timeout) {
             if (this.visible) {
                 (function () {
-                    if (!_this2.reportLocation) {
+                    if (!_this.reportLocation) {
                         var _error = new Error("KA_INFINITE_LOOP");
-                        _this2.callback(_error);
+                        _this.callback(_error);
                         throw _error;
                     }
 
@@ -87491,9 +87489,9 @@ window.LoopProtector.prototype = {
                     // the most calls.
                     var max = 0; // current max count
                     var hotLocation = null; // callsite with most calls
-                    Object.keys(_this2.loopCounts).forEach(function (location) {
-                        if (_this2.loopCounts[location] > max) {
-                            max = _this2.loopCounts[location];
+                    Object.keys(_this.loopCounts).forEach(function (location) {
+                        if (_this.loopCounts[location] > max) {
+                            max = _this.loopCounts[location];
                             hotLocation = location;
                         }
                     });
@@ -87505,7 +87503,7 @@ window.LoopProtector.prototype = {
                         row: hotLocation.loc.start.line - 1 // ace uses 0-indexed rows
                     };
 
-                    _this2.callback(error);
+                    _this.callback(error);
 
                     // We throw here to interrupt communication but also to
                     throw error;

--- a/build/js/live-editor.output_pjs_deps.js
+++ b/build/js/live-editor.output_pjs_deps.js
@@ -86257,7 +86257,7 @@ require("/tools/entry-point.js");
 
     if (typeof module !== "undefined" && module.exports) {
         exports = module.exports = {};
-        esprima = require("./external/esprima.js");
+        esprima = require("esprima");
         _ = require("underscore");
     } else {
         exports = this.Structured = {};
@@ -86290,116 +86290,6 @@ require("/tools/entry-point.js");
             variables: params,
             fn: callback
         };
-    }
-    
-    /*
-     * return true if n2 < n1 (according to relatively arbitrary criteria)
-     */
-    function shouldSwap(n1, n2) {
-	if (n1.type < n2.type) { //Sort by node type if different
-	    return false;
-	} else if (n1.type > n2.type) {
-	    return true;
-	} else if (n1.type === "Literal") { //Sort by value if they're literals
-	    return n1.raw > n2.raw;
-	} else { //Otherwise, loop through the properties until a difference is found and sort by that
-	    for (var k in n1) {
-		if (n1[k].hasOwnProperty("type") && n1[k] !== n2[k]) {
-		    return shouldSwap(n1[k], n2[k]);
-		}
-	    }
-	}
-    }
-    function standardizeTree(tree) {
-	if (!tree) {return tree;}
-        var r = deepClone(tree);
-        switch (tree.type) {
-            case "BinaryExpression":
-                if (_.contains(["*", "+", "===", "!==", "==", "!=", "&", "|", "^"], tree.operator)) {
-		    if (shouldSwap(tree.left, tree.right)) {
-			r.left = standardizeTree(tree.right);
-			r.right = standardizeTree(tree.left);
-            } else {
-                r.left = standardizeTree(tree.left);
-                r.right = standardizeTree(tree.right);
-            }
-		} else if (tree.operator[0] === ">") {
-		    r.operator = "<" + tree.operator.slice(1);
-		    r.left = standardizeTree(tree.right);
-		    r.right = standardizeTree(tree.left);
-		} break;
-	    case "LogicalExpression":
-	        if (_.contains(["&&", "||"], tree.operator) &&
-		    shouldSwap(tree.left, tree.right)) {
-		    r.left = standardizeTree(tree.right);
-		    r.right = standardizeTree(tree.left);
-		} break;
-	    case "AssignmentExpression":
-	        if (_.contains(["+=", "-=", "*=", "/=", "%=", "<<=", ">>=", ">>>=", "&=", "^=", "|="], tree.operator)) {
-		    var l = standardizeTree(tree.left);
-		    r = {type: "AssignmentExpression",
-			 operator: "=",
-			 left: l,
-			 right: {type: "BinaryExpression",
-				 operator: tree.operator.slice(0,-1),
-				 left: l,
-				 right: standardizeTree(tree.right)}};
-		} else {
-            r.left = standardizeTree(r.left);
-            r.right = standardizeTree(r.right);
-        } break;
-	    case "UpdateExpression":
-	        if (_.contains(["++", "--"], tree.operator)) {
-		    var l = standardizeTree(tree.argument);
-		    r = {type: "AssignmentExpression",
-			 operator: "=",
-			 left: l,
-			 right: {type: "BinaryExpression",
-				 operator: tree.operator[0],
-				 left: l,
-				 right: {type: "Literal",
-					 value: 1,
-					 raw: "1"}}};
-		} break;
-	    case "VariableDeclaration":
-	        if (tree.kind === "var") {
-		    r = [deepClone(tree)];
-		    for (var i in tree.declarations) {
-			if (tree.declarations[i].type === "VariableDeclarator" &&
-			    tree.declarations[i].init !== null) {
-			    r.push({type: "ExpressionStatement",
-				    expression: {type: "AssignmentExpression",
-						 operator: "=",
-						 left: tree.declarations[i].id,
-						 right: standardizeTree(tree.declarations[i].init)}});
-			    r[0].declarations[i].init = null;
-			}
-		    }
-		} break;
-        case "Literal":
-            r.raw = tree.raw
-                .replace(/^(?:\"(.*?)\"|\'(.*?)\')$/, function(match, p1, p2) {
-                    return "\"" + ((p1 || "") + (p2 || ""))
-                        .replace(/"|'/g, "\"") + "\"";
-                });
-            console.log(r.raw); break;
-	    default:
-	        for (var key in tree) {
-		    if (!tree.hasOwnProperty(key) || !_.isObject(tree[key])) {
-			continue;
-		    }
-		    if (_.isArray(tree[key])) {
-			var ar = [];
-			for (var i in tree[key]) {  /* jshint forin:false */
-			    ar = ar.concat(standardizeTree(tree[key][i]));
-			}
-			r[key] = ar;
-		    } else {
-			r[key] = standardizeTree(tree[key]);
-		    }
-		}
-        }
-        return r;
     }
 
     /*
@@ -86511,7 +86401,6 @@ require("/tools/entry-point.js");
             _: [],
             vars: {}
         };
-	codeTree = standardizeTree(codeTree);
         if (wildcardVars.order.length === 0 || options.single) {
             // With no vars to match, our normal greedy approach works great.
             result = checkMatchTree(codeTree, toFind, peers, wildcardVars, matchResult, options);
@@ -86626,7 +86515,7 @@ require("/tools/entry-point.js");
     function checkUserVarCallbacks(wVars, varCallbacks) {
         // Clear old failure message if needed
         delete originalVarCallbacks.failure;
-        for (var key in varCallbacks) {  /* jshint forin:false */
+        for (var key in varCallbacks) {
             // Property strings may be "$foo, $bar, $baz" to mimic arrays.
             var varNames = varCallbacks[key].variables;
             var varValues = _.map(varNames, function(varName) {
@@ -86700,7 +86589,7 @@ require("/tools/entry-point.js");
      *        relative ordering matter).
      */
     function parseStructureWithVars(structure, wVars) {
-        var tree = standardizeTree(parseStructure(structure));
+        var tree = parseStructure(structure);
         foldConstants(tree);
         simplifyTree(tree, wVars);
         return tree;
@@ -86710,7 +86599,7 @@ require("/tools/entry-point.js");
      * Constant folds the syntax tree
      */
     function foldConstants(tree) {
-        for (var key in tree) {  /* jshint forin:false */
+        for (var key in tree) {
             if (!tree.hasOwnProperty(key)) {
                 continue; // Inherited property
             }
@@ -86724,7 +86613,6 @@ require("/tools/entry-point.js");
                  * This is easy to extend, but it means we lose the ability to match
                  * potentially useful expressions like 5 + 5 with a pattern like _ + _.
                  */
-                /* jshint eqeqeq:false */
                 if (ast.type == esprima.Syntax.UnaryExpression) {
                     var argument = ast.argument;
                     if (argument.type === esprima.Syntax.Literal &&
@@ -86764,7 +86652,7 @@ require("/tools/entry-point.js");
      *
      */
     function simplifyTree(tree, wVars) {
-        for (var key in tree) {  /* jshint forin:false */
+        for (var key in tree) {
             if (!tree.hasOwnProperty(key)) {
                 continue; // Inherited property
             }
@@ -86826,14 +86714,12 @@ require("/tools/entry-point.js");
      * toFind: The syntax node from the structure that we wish to find.
      * peersToFind: The remaining ordered syntax nodes that we must find after
      *     toFind (and on the same level as toFind).
-     * modify: should it call RestructureTree()?
      */
     function checkMatchTree(currTree, toFind, peersToFind, wVars, matchResults, options) {
         if (_.isArray(toFind)) {
             console.error("toFind should never be an array.");
             console.error(toFind);
         }
-        /* jshint -W041, -W116 */
         if (currTree == undefined) {
             if (toFind == undefined) {
                 matchResults._.push(currTree);
@@ -86850,15 +86736,15 @@ require("/tools/entry-point.js");
             return false;
         }
         // Check children.
-        for (var key in currTree) {  /* jshint forin:false */
+        for (var key in currTree) {
             if (!currTree.hasOwnProperty(key) || !_.isObject(currTree[key])) {
                 continue; // Skip inherited properties
             }
             // Recursively check for matches
             if ((_.isArray(currTree[key]) &&
-                    checkNodeArray(currTree[key], toFind, peersToFind, wVars, matchResults, options, true)) ||
+                    checkNodeArray(currTree[key], toFind, peersToFind, wVars, matchResults, options)) ||
                 (!_.isArray(currTree[key]) &&
-                    checkMatchTree(currTree[key], toFind, peersToFind, wVars, matchResults, options, true))) {
+                    checkMatchTree(currTree[key], toFind, peersToFind, wVars, matchResults, options))) {
                 return matchResults;
             }
         }
@@ -87015,7 +86901,7 @@ require("/tools/entry-point.js");
             rootToSet = currNode;
         }
 
-        for (var key in toFind) {  /* jshint forin:false */
+        for (var key in toFind) {
             // Ignore inherited properties; also, null properties can be
             // anything and do not have to exist.
             if (!toFind.hasOwnProperty(key) || toFind[key] === null) {
@@ -87025,7 +86911,6 @@ require("/tools/entry-point.js");
             var subCurr = currNode[key];
             // Undefined properties can be anything, but they must exist.
             if (subFind === undefined) {
-                /* jshint -W116 */
                 if (subCurr == undefined) {
                     return false;
                 } else {
@@ -87246,7 +87131,7 @@ require("/tools/entry-point.js");
             return node;
         }
 
-        for (var prop in node) {  /* jshint forin:false */
+        for (var prop in node) {
             if (!node.hasOwnProperty(prop)) {
                 continue;
             }

--- a/build/js/live-editor.output_pjs_deps.js
+++ b/build/js/live-editor.output_pjs_deps.js
@@ -87417,6 +87417,8 @@ window.walkAST = function (node, path, visitors) {
  * @constructor
  */
 window.LoopProtector = function (callback, timeouts, reportLocation) {
+    var _this = this;
+
     this.callback = callback || function () {};
     this.timeout = 200;
     this.branchStartTime = 0;
@@ -87433,14 +87435,14 @@ window.LoopProtector = function (callback, timeouts, reportLocation) {
     this.KAInfiniteLoopProtect = this._KAInfiniteLoopProtect.bind(this);
     this.KAInfiniteLoopSetTimeout = this._KAInfiniteLoopSetTimeout.bind(this);
 
-    document.addEventListener("visibilitychange", (function () {
+    document.addEventListener("visibilitychange", function () {
         if (document.hidden) {
-            this.visible = true;
-            this.branchStartTime = 0;
+            _this.visible = true;
+            _this.branchStartTime = 0;
         } else {
-            this.visible = false;
+            _this.visible = false;
         }
-    }).bind(this));
+    });
 
     this.visible = !document.hidden;
 };
@@ -87462,7 +87464,7 @@ window.LoopProtector.prototype = {
      * @private
      */
     _KAInfiniteLoopProtect: function _KAInfiniteLoopProtect(location) {
-        var _this = this;
+        var _this2 = this;
 
         if (location) {
             if (!this.loopCounts[location]) {
@@ -87479,9 +87481,9 @@ window.LoopProtector.prototype = {
         } else if (now - this.branchStartTime > this.timeout) {
             if (this.visible) {
                 (function () {
-                    if (!_this.reportLocation) {
+                    if (!_this2.reportLocation) {
                         var _error = new Error("KA_INFINITE_LOOP");
-                        _this.callback(_error);
+                        _this2.callback(_error);
                         throw _error;
                     }
 
@@ -87489,9 +87491,9 @@ window.LoopProtector.prototype = {
                     // the most calls.
                     var max = 0; // current max count
                     var hotLocation = null; // callsite with most calls
-                    Object.keys(_this.loopCounts).forEach(function (location) {
-                        if (_this.loopCounts[location] > max) {
-                            max = _this.loopCounts[location];
+                    Object.keys(_this2.loopCounts).forEach(function (location) {
+                        if (_this2.loopCounts[location] > max) {
+                            max = _this2.loopCounts[location];
                             hotLocation = location;
                         }
                     });
@@ -87503,7 +87505,7 @@ window.LoopProtector.prototype = {
                         row: hotLocation.loc.start.line - 1 // ace uses 0-indexed rows
                     };
 
-                    _this.callback(error);
+                    _this2.callback(error);
 
                     // We throw here to interrupt communication but also to
                     throw error;

--- a/build/js/live-editor.output_pjs_deps.js
+++ b/build/js/live-editor.output_pjs_deps.js
@@ -86376,13 +86376,13 @@ require("/tools/entry-point.js");
 			}
 		    }
 		} break;
-            case "Literal":
-                r.raw = tree.raw
-                    .replace(/^(?:\"(.*?)\"|\'(.*?)\')$/, function(match, p1, p2) {
-                        return "\"" + ((p1 || "") + (p2 || ""))
-                            .replace(/"|'/g, "\"") + "\"";
-                    });
-                break;
+        case "Literal":
+            r.raw = tree.raw
+                .replace(/^(?:\"(.*?)\"|\'(.*?)\')$/, function(match, p1, p2) {
+                    return "\"" + ((p1 || "") + (p2 || ""))
+                        .replace(/"|'/g, "\"") + "\"";
+                });
+            console.log(r.raw); break;
 	    default:
 	        for (var key in tree) {
 		    if (!tree.hasOwnProperty(key) || !_.isObject(tree[key])) {

--- a/build/js/live-editor.output_webpage_deps.js
+++ b/build/js/live-editor.output_webpage_deps.js
@@ -11902,8 +11902,6 @@ window.walkAST = function (node, path, visitors) {
  * @constructor
  */
 window.LoopProtector = function (callback, timeouts, reportLocation) {
-    var _this = this;
-
     this.callback = callback || function () {};
     this.timeout = 200;
     this.branchStartTime = 0;
@@ -11920,14 +11918,14 @@ window.LoopProtector = function (callback, timeouts, reportLocation) {
     this.KAInfiniteLoopProtect = this._KAInfiniteLoopProtect.bind(this);
     this.KAInfiniteLoopSetTimeout = this._KAInfiniteLoopSetTimeout.bind(this);
 
-    document.addEventListener("visibilitychange", function () {
+    document.addEventListener("visibilitychange", (function () {
         if (document.hidden) {
-            _this.visible = true;
-            _this.branchStartTime = 0;
+            this.visible = true;
+            this.branchStartTime = 0;
         } else {
-            _this.visible = false;
+            this.visible = false;
         }
-    });
+    }).bind(this));
 
     this.visible = !document.hidden;
 };
@@ -11949,7 +11947,7 @@ window.LoopProtector.prototype = {
      * @private
      */
     _KAInfiniteLoopProtect: function _KAInfiniteLoopProtect(location) {
-        var _this2 = this;
+        var _this = this;
 
         if (location) {
             if (!this.loopCounts[location]) {
@@ -11966,9 +11964,9 @@ window.LoopProtector.prototype = {
         } else if (now - this.branchStartTime > this.timeout) {
             if (this.visible) {
                 (function () {
-                    if (!_this2.reportLocation) {
+                    if (!_this.reportLocation) {
                         var _error = new Error("KA_INFINITE_LOOP");
-                        _this2.callback(_error);
+                        _this.callback(_error);
                         throw _error;
                     }
 
@@ -11976,9 +11974,9 @@ window.LoopProtector.prototype = {
                     // the most calls.
                     var max = 0; // current max count
                     var hotLocation = null; // callsite with most calls
-                    Object.keys(_this2.loopCounts).forEach(function (location) {
-                        if (_this2.loopCounts[location] > max) {
-                            max = _this2.loopCounts[location];
+                    Object.keys(_this.loopCounts).forEach(function (location) {
+                        if (_this.loopCounts[location] > max) {
+                            max = _this.loopCounts[location];
                             hotLocation = location;
                         }
                     });
@@ -11990,7 +11988,7 @@ window.LoopProtector.prototype = {
                         row: hotLocation.loc.start.line - 1 // ace uses 0-indexed rows
                     };
 
-                    _this2.callback(error);
+                    _this.callback(error);
 
                     // We throw here to interrupt communication but also to
                     throw error;

--- a/build/js/live-editor.output_webpage_deps.js
+++ b/build/js/live-editor.output_webpage_deps.js
@@ -12274,13 +12274,13 @@ window.StateScrubber.prototype = {
 			}
 		    }
 		} break;
-            case "Literal":
-                r.raw = tree.raw
-                    .replace(/^(?:\"(.*?)\"|\'(.*?)\')$/, function(match, p1, p2) {
-                        return "\"" + ((p1 || "") + (p2 || ""))
-                            .replace(/"|'/g, "\"") + "\"";
-                    });
-                break;
+        case "Literal":
+            r.raw = tree.raw
+                .replace(/^(?:\"(.*?)\"|\'(.*?)\')$/, function(match, p1, p2) {
+                    return "\"" + ((p1 || "") + (p2 || ""))
+                        .replace(/"|'/g, "\"") + "\"";
+                });
+            console.log(r.raw); break;
 	    default:
 	        for (var key in tree) {
 		    if (!tree.hasOwnProperty(key) || !_.isObject(tree[key])) {

--- a/build/js/live-editor.output_webpage_deps.js
+++ b/build/js/live-editor.output_webpage_deps.js
@@ -11902,6 +11902,8 @@ window.walkAST = function (node, path, visitors) {
  * @constructor
  */
 window.LoopProtector = function (callback, timeouts, reportLocation) {
+    var _this = this;
+
     this.callback = callback || function () {};
     this.timeout = 200;
     this.branchStartTime = 0;
@@ -11918,14 +11920,14 @@ window.LoopProtector = function (callback, timeouts, reportLocation) {
     this.KAInfiniteLoopProtect = this._KAInfiniteLoopProtect.bind(this);
     this.KAInfiniteLoopSetTimeout = this._KAInfiniteLoopSetTimeout.bind(this);
 
-    document.addEventListener("visibilitychange", (function () {
+    document.addEventListener("visibilitychange", function () {
         if (document.hidden) {
-            this.visible = true;
-            this.branchStartTime = 0;
+            _this.visible = true;
+            _this.branchStartTime = 0;
         } else {
-            this.visible = false;
+            _this.visible = false;
         }
-    }).bind(this));
+    });
 
     this.visible = !document.hidden;
 };
@@ -11947,7 +11949,7 @@ window.LoopProtector.prototype = {
      * @private
      */
     _KAInfiniteLoopProtect: function _KAInfiniteLoopProtect(location) {
-        var _this = this;
+        var _this2 = this;
 
         if (location) {
             if (!this.loopCounts[location]) {
@@ -11964,9 +11966,9 @@ window.LoopProtector.prototype = {
         } else if (now - this.branchStartTime > this.timeout) {
             if (this.visible) {
                 (function () {
-                    if (!_this.reportLocation) {
+                    if (!_this2.reportLocation) {
                         var _error = new Error("KA_INFINITE_LOOP");
-                        _this.callback(_error);
+                        _this2.callback(_error);
                         throw _error;
                     }
 
@@ -11974,9 +11976,9 @@ window.LoopProtector.prototype = {
                     // the most calls.
                     var max = 0; // current max count
                     var hotLocation = null; // callsite with most calls
-                    Object.keys(_this.loopCounts).forEach(function (location) {
-                        if (_this.loopCounts[location] > max) {
-                            max = _this.loopCounts[location];
+                    Object.keys(_this2.loopCounts).forEach(function (location) {
+                        if (_this2.loopCounts[location] > max) {
+                            max = _this2.loopCounts[location];
                             hotLocation = location;
                         }
                     });
@@ -11988,7 +11990,7 @@ window.LoopProtector.prototype = {
                         row: hotLocation.loc.start.line - 1 // ace uses 0-indexed rows
                     };
 
-                    _this.callback(error);
+                    _this2.callback(error);
 
                     // We throw here to interrupt communication but also to
                     throw error;

--- a/build/js/live-editor.output_webpage_deps.js
+++ b/build/js/live-editor.output_webpage_deps.js
@@ -11902,6 +11902,8 @@ window.walkAST = function (node, path, visitors) {
  * @constructor
  */
 window.LoopProtector = function (callback, timeouts, reportLocation) {
+    var _this = this;
+
     this.callback = callback || function () {};
     this.timeout = 200;
     this.branchStartTime = 0;
@@ -11918,16 +11920,16 @@ window.LoopProtector = function (callback, timeouts, reportLocation) {
     this.KAInfiniteLoopProtect = this._KAInfiniteLoopProtect.bind(this);
     this.KAInfiniteLoopSetTimeout = this._KAInfiniteLoopSetTimeout.bind(this);
 
-    visibly.onVisible((function () {
-        this.visible = true;
-        this.branchStartTime = 0;
-    }).bind(this));
+    document.addEventListener("visibilitychange", function () {
+        if (document.hidden) {
+            _this.visible = true;
+            _this.branchStartTime = 0;
+        } else {
+            _this.visible = false;
+        }
+    });
 
-    visibly.onHidden((function () {
-        this.visible = false;
-    }).bind(this));
-
-    this.visible = !visibly.hidden();
+    this.visible = !document.hidden;
 };
 
 window.LoopProtector.prototype = {
@@ -11947,7 +11949,7 @@ window.LoopProtector.prototype = {
      * @private
      */
     _KAInfiniteLoopProtect: function _KAInfiniteLoopProtect(location) {
-        var _this = this;
+        var _this2 = this;
 
         if (location) {
             if (!this.loopCounts[location]) {
@@ -11964,9 +11966,9 @@ window.LoopProtector.prototype = {
         } else if (now - this.branchStartTime > this.timeout) {
             if (this.visible) {
                 (function () {
-                    if (!_this.reportLocation) {
+                    if (!_this2.reportLocation) {
                         var _error = new Error("KA_INFINITE_LOOP");
-                        _this.callback(_error);
+                        _this2.callback(_error);
                         throw _error;
                     }
 
@@ -11974,9 +11976,9 @@ window.LoopProtector.prototype = {
                     // the most calls.
                     var max = 0; // current max count
                     var hotLocation = null; // callsite with most calls
-                    Object.keys(_this.loopCounts).forEach(function (location) {
-                        if (_this.loopCounts[location] > max) {
-                            max = _this.loopCounts[location];
+                    Object.keys(_this2.loopCounts).forEach(function (location) {
+                        if (_this2.loopCounts[location] > max) {
+                            max = _this2.loopCounts[location];
                             hotLocation = location;
                         }
                     });
@@ -11988,7 +11990,7 @@ window.LoopProtector.prototype = {
                         row: hotLocation.loc.start.line - 1 // ace uses 0-indexed rows
                     };
 
-                    _this.callback(error);
+                    _this2.callback(error);
 
                     // We throw here to interrupt communication but also to
                     throw error;
@@ -12153,7 +12155,7 @@ window.StateScrubber.prototype = {
 
     if (typeof module !== "undefined" && module.exports) {
         exports = module.exports = {};
-        esprima = require("esprima");
+        esprima = require("./external/esprima.js");
         _ = require("underscore");
     } else {
         exports = this.Structured = {};
@@ -12186,6 +12188,116 @@ window.StateScrubber.prototype = {
             variables: params,
             fn: callback
         };
+    }
+    
+    /*
+     * return true if n2 < n1 (according to relatively arbitrary criteria)
+     */
+    function shouldSwap(n1, n2) {
+	if (n1.type < n2.type) { //Sort by node type if different
+	    return false;
+	} else if (n1.type > n2.type) {
+	    return true;
+	} else if (n1.type === "Literal") { //Sort by value if they're literals
+	    return n1.raw > n2.raw;
+	} else { //Otherwise, loop through the properties until a difference is found and sort by that
+	    for (var k in n1) {
+		if (n1[k].hasOwnProperty("type") && n1[k] !== n2[k]) {
+		    return shouldSwap(n1[k], n2[k]);
+		}
+	    }
+	}
+    }
+    function standardizeTree(tree) {
+	if (!tree) {return tree;}
+        var r = deepClone(tree);
+        switch (tree.type) {
+            case "BinaryExpression":
+                if (_.contains(["*", "+", "===", "!==", "==", "!=", "&", "|", "^"], tree.operator)) {
+		    if (shouldSwap(tree.left, tree.right)) {
+			r.left = standardizeTree(tree.right);
+			r.right = standardizeTree(tree.left);
+            } else {
+                r.left = standardizeTree(tree.left);
+                r.right = standardizeTree(tree.right);
+            }
+		} else if (tree.operator[0] === ">") {
+		    r.operator = "<" + tree.operator.slice(1);
+		    r.left = standardizeTree(tree.right);
+		    r.right = standardizeTree(tree.left);
+		} break;
+	    case "LogicalExpression":
+	        if (_.contains(["&&", "||"], tree.operator) &&
+		    shouldSwap(tree.left, tree.right)) {
+		    r.left = standardizeTree(tree.right);
+		    r.right = standardizeTree(tree.left);
+		} break;
+	    case "AssignmentExpression":
+	        if (_.contains(["+=", "-=", "*=", "/=", "%=", "<<=", ">>=", ">>>=", "&=", "^=", "|="], tree.operator)) {
+		    var l = standardizeTree(tree.left);
+		    r = {type: "AssignmentExpression",
+			 operator: "=",
+			 left: l,
+			 right: {type: "BinaryExpression",
+				 operator: tree.operator.slice(0,-1),
+				 left: l,
+				 right: standardizeTree(tree.right)}};
+		} else {
+            r.left = standardizeTree(r.left);
+            r.right = standardizeTree(r.right);
+        } break;
+	    case "UpdateExpression":
+	        if (_.contains(["++", "--"], tree.operator)) {
+		    var l = standardizeTree(tree.argument);
+		    r = {type: "AssignmentExpression",
+			 operator: "=",
+			 left: l,
+			 right: {type: "BinaryExpression",
+				 operator: tree.operator[0],
+				 left: l,
+				 right: {type: "Literal",
+					 value: 1,
+					 raw: "1"}}};
+		} break;
+	    case "VariableDeclaration":
+	        if (tree.kind === "var") {
+		    r = [deepClone(tree)];
+		    for (var i in tree.declarations) {
+			if (tree.declarations[i].type === "VariableDeclarator" &&
+			    tree.declarations[i].init !== null) {
+			    r.push({type: "ExpressionStatement",
+				    expression: {type: "AssignmentExpression",
+						 operator: "=",
+						 left: tree.declarations[i].id,
+						 right: standardizeTree(tree.declarations[i].init)}});
+			    r[0].declarations[i].init = null;
+			}
+		    }
+		} break;
+            case "Literal":
+                r.raw = tree.raw
+                    .replace(/^(?:\"(.*?)\"|\'(.*?)\')$/, function(match, p1, p2) {
+                        return "\"" + ((p1 || "") + (p2 || ""))
+                            .replace(/"|'/g, "\"") + "\"";
+                    });
+                break;
+	    default:
+	        for (var key in tree) {
+		    if (!tree.hasOwnProperty(key) || !_.isObject(tree[key])) {
+			continue;
+		    }
+		    if (_.isArray(tree[key])) {
+			var ar = [];
+			for (var i in tree[key]) {  /* jshint forin:false */
+			    ar = ar.concat(standardizeTree(tree[key][i]));
+			}
+			r[key] = ar;
+		    } else {
+			r[key] = standardizeTree(tree[key]);
+		    }
+		}
+        }
+        return r;
     }
 
     /*
@@ -12297,6 +12409,7 @@ window.StateScrubber.prototype = {
             _: [],
             vars: {}
         };
+	codeTree = standardizeTree(codeTree);
         if (wildcardVars.order.length === 0 || options.single) {
             // With no vars to match, our normal greedy approach works great.
             result = checkMatchTree(codeTree, toFind, peers, wildcardVars, matchResult, options);
@@ -12411,7 +12524,7 @@ window.StateScrubber.prototype = {
     function checkUserVarCallbacks(wVars, varCallbacks) {
         // Clear old failure message if needed
         delete originalVarCallbacks.failure;
-        for (var key in varCallbacks) {
+        for (var key in varCallbacks) {  /* jshint forin:false */
             // Property strings may be "$foo, $bar, $baz" to mimic arrays.
             var varNames = varCallbacks[key].variables;
             var varValues = _.map(varNames, function(varName) {
@@ -12485,7 +12598,7 @@ window.StateScrubber.prototype = {
      *        relative ordering matter).
      */
     function parseStructureWithVars(structure, wVars) {
-        var tree = parseStructure(structure);
+        var tree = standardizeTree(parseStructure(structure));
         foldConstants(tree);
         simplifyTree(tree, wVars);
         return tree;
@@ -12495,7 +12608,7 @@ window.StateScrubber.prototype = {
      * Constant folds the syntax tree
      */
     function foldConstants(tree) {
-        for (var key in tree) {
+        for (var key in tree) {  /* jshint forin:false */
             if (!tree.hasOwnProperty(key)) {
                 continue; // Inherited property
             }
@@ -12509,6 +12622,7 @@ window.StateScrubber.prototype = {
                  * This is easy to extend, but it means we lose the ability to match
                  * potentially useful expressions like 5 + 5 with a pattern like _ + _.
                  */
+                /* jshint eqeqeq:false */
                 if (ast.type == esprima.Syntax.UnaryExpression) {
                     var argument = ast.argument;
                     if (argument.type === esprima.Syntax.Literal &&
@@ -12548,7 +12662,7 @@ window.StateScrubber.prototype = {
      *
      */
     function simplifyTree(tree, wVars) {
-        for (var key in tree) {
+        for (var key in tree) {  /* jshint forin:false */
             if (!tree.hasOwnProperty(key)) {
                 continue; // Inherited property
             }
@@ -12610,12 +12724,14 @@ window.StateScrubber.prototype = {
      * toFind: The syntax node from the structure that we wish to find.
      * peersToFind: The remaining ordered syntax nodes that we must find after
      *     toFind (and on the same level as toFind).
+     * modify: should it call RestructureTree()?
      */
     function checkMatchTree(currTree, toFind, peersToFind, wVars, matchResults, options) {
         if (_.isArray(toFind)) {
             console.error("toFind should never be an array.");
             console.error(toFind);
         }
+        /* jshint -W041, -W116 */
         if (currTree == undefined) {
             if (toFind == undefined) {
                 matchResults._.push(currTree);
@@ -12632,15 +12748,15 @@ window.StateScrubber.prototype = {
             return false;
         }
         // Check children.
-        for (var key in currTree) {
+        for (var key in currTree) {  /* jshint forin:false */
             if (!currTree.hasOwnProperty(key) || !_.isObject(currTree[key])) {
                 continue; // Skip inherited properties
             }
             // Recursively check for matches
             if ((_.isArray(currTree[key]) &&
-                    checkNodeArray(currTree[key], toFind, peersToFind, wVars, matchResults, options)) ||
+                    checkNodeArray(currTree[key], toFind, peersToFind, wVars, matchResults, options, true)) ||
                 (!_.isArray(currTree[key]) &&
-                    checkMatchTree(currTree[key], toFind, peersToFind, wVars, matchResults, options))) {
+                    checkMatchTree(currTree[key], toFind, peersToFind, wVars, matchResults, options, true))) {
                 return matchResults;
             }
         }
@@ -12797,7 +12913,7 @@ window.StateScrubber.prototype = {
             rootToSet = currNode;
         }
 
-        for (var key in toFind) {
+        for (var key in toFind) {  /* jshint forin:false */
             // Ignore inherited properties; also, null properties can be
             // anything and do not have to exist.
             if (!toFind.hasOwnProperty(key) || toFind[key] === null) {
@@ -12807,6 +12923,7 @@ window.StateScrubber.prototype = {
             var subCurr = currNode[key];
             // Undefined properties can be anything, but they must exist.
             if (subFind === undefined) {
+                /* jshint -W116 */
                 if (subCurr == undefined) {
                     return false;
                 } else {
@@ -13027,7 +13144,7 @@ window.StateScrubber.prototype = {
             return node;
         }
 
-        for (var prop in node) {
+        for (var prop in node) {  /* jshint forin:false */
             if (!node.hasOwnProperty(prop)) {
                 continue;
             }

--- a/js/output/shared/loop-protect.js
+++ b/js/output/shared/loop-protect.js
@@ -27,14 +27,14 @@ window.LoopProtector = function(callback, timeouts, reportLocation) {
     this.KAInfiniteLoopProtect = this._KAInfiniteLoopProtect.bind(this);
     this.KAInfiniteLoopSetTimeout = this._KAInfiniteLoopSetTimeout.bind(this);
 
-    document.addEventListener('visibilitychange', () => {
+    document.addEventListener('visibilitychange', function() {
         if (document.hidden) {
             this.visible = true;
             this.branchStartTime = 0;
         } else {
             this.visible = false;
         }
-    });
+    }.bind(this));
 
     this.visible = !document.hidden;
 };

--- a/js/output/shared/loop-protect.js
+++ b/js/output/shared/loop-protect.js
@@ -27,16 +27,16 @@ window.LoopProtector = function(callback, timeouts, reportLocation) {
     this.KAInfiniteLoopProtect = this._KAInfiniteLoopProtect.bind(this);
     this.KAInfiniteLoopSetTimeout = this._KAInfiniteLoopSetTimeout.bind(this);
 
-    visibly.onVisible(function () {
-        this.visible = true;
-        this.branchStartTime = 0;
-    }.bind(this));
+    document.addEventListener('visibilitychange', () => {
+        if (document.hidden) {
+            this.visible = true;
+            this.branchStartTime = 0;
+        } else {
+            this.visible = false;
+        }
+    });
 
-    visibly.onHidden(function () {
-        this.visible = false;
-    }.bind(this));
-
-    this.visible = !visibly.hidden();
+    this.visible = !document.hidden;
 };
 
 window.LoopProtector.prototype = {

--- a/js/output/shared/loop-protect.js
+++ b/js/output/shared/loop-protect.js
@@ -27,14 +27,14 @@ window.LoopProtector = function(callback, timeouts, reportLocation) {
     this.KAInfiniteLoopProtect = this._KAInfiniteLoopProtect.bind(this);
     this.KAInfiniteLoopSetTimeout = this._KAInfiniteLoopSetTimeout.bind(this);
 
-    document.addEventListener('visibilitychange', function() {
+    document.addEventListener('visibilitychange', () => {
         if (document.hidden) {
             this.visible = true;
             this.branchStartTime = 0;
         } else {
             this.visible = false;
         }
-    }.bind(this));
+    });
 
     this.visible = !document.hidden;
 };


### PR DESCRIPTION
### High-level description of change

This replaces the visibly submodule with the Page Visibility API, now supported in all relevant browsers. See: https://caniuse.com/#feat=pagevisibility

### Are there performance implications for this change?

One less module, so smaller size! (Also, visibly was likely polling. Native is better).

### Have you added tests to cover this new/updated code?

No, I ran previous tests and ran the manual test.

### Risks involved

There could be a subtle difference between visibly and the visibility API? Hopefully not, since visibly was a polyfill.

### Are there any dependencies or blockers for merging this?

No.

### How can we verify that this change works?
- copy/paste the example from #260 into the demo app
- hide the browser or switch to a different tab and wait for ~2 minutes
- return to the demo page and verify that the script has continued to run uninterrupted

Taken from the original visibly PR: https://github.com/Khan/live-editor/commit/6b3b5e505179649c1a291d1dcfe76872b463ee0a

