### PR TITLE
Port from jQuery to DOM in WebpageTester, fix the associated tests

### DIFF
--- a/build/js/live-editor.output_webpage.js
+++ b/build/js/live-editor.output_webpage.js
@@ -9,6 +9,8 @@
 
     _.extend(WebpageTester.prototype, {
         test: function test(userCode, validate, errors, callback) {
+            var _this = this;
+
             var testResults = [];
             errors = this.errors = errors || [];
             this.userCode = userCode;
@@ -24,10 +26,10 @@
             var parser = new DOMParser();
             var doc = parser.parseFromString(userCode, "text/html");
 
-            $(doc).find("script").each((function (index, scriptElement) {
-                this.testContext.allScripts += scriptElement.innerHTML;
-                this.testContext.allScripts += "\n";
-            }).bind(this));
+            doc.querySelectorAll("script").forEach(function (scriptElement) {
+                _this.testContext.allScripts += scriptElement.innerHTML;
+                _this.testContext.allScripts += "\n";
+            });
 
             this.curTask = null;
             this.curTest = null;
@@ -160,7 +162,7 @@
                 var expected = structure[selector];
                 // TODO(jeresig): Maybe find a way to do this such that we can run
                 // it in a worker thread.
-                var numFound = $(selector, this.testContext.$docSP).length;
+                var numFound = this.testContext.docSP.querySelectorAll(selector).length;
                 if (expected === 0 && numFound !== 0 || numFound < expected) {
                     return { success: false };
                 }
@@ -803,8 +805,7 @@ window.WebpageOutput = Backbone.View.extend({
 
         _.extend(this.tester.testContext, {
             $doc: $(this.frameDoc),
-            // Append to a div because jQuery doesn't work on a document fragment
-            $docSP: $("<div>").append(this.slowparseResults.document),
+            docSP: this.slowparseResults.document,
             cssRules: this.slowparseResults.rules
         });
 

--- a/build/js/live-editor.shared.js
+++ b/build/js/live-editor.shared.js
@@ -136,6 +136,10 @@ window.ScratchpadRecord = Backbone.Model.extend({
         // Array of command arrays for each chunk. Only holds chunks that
         // have been saved.
         this.allSavedCommands = [];
+
+        // True when we actively seeking to a new position and potentially
+        // building the cache.
+        this.seeking = false;
     },
 
     setActualInitData: function setActualInitData(actualData) {
@@ -256,6 +260,14 @@ window.ScratchpadRecord = Backbone.Model.extend({
     // Seek to a given position in the playback, executing all the
     // commands in the interim
     seekTo: function seekTo(time) {
+        var _this = this;
+
+        if (this.seeking) {
+            return;
+        }
+
+        this.seeking = true;
+
         // Initialize and seek to the desired position
         this.pauseTime = new Date().getTime();
         this.playStart = this.pauseTime - time;
@@ -303,13 +315,30 @@ window.ScratchpadRecord = Backbone.Model.extend({
             this.cacheRestore(-1 * this.seekCacheInterval);
         }
 
-        // Execute commands and build cache, bringing state up to current
-        for (var i = cacheOffset; i <= seekPos; i++) {
-            this.runCommand(this.commands[i]);
-            this.cache(i);
-        }
+        // To prevent the screen locking up while seeking ahead, processing
+        // commands, and building the cache, we can use requestAnimationFrame
+        // to process a few commands and cache entries, then see if we need to
+        // update the browser before processing another block of commands.
+        var currentOffset = cacheOffset;
+        var buildCache = function buildCache() {
+            var animationStep = 100;
+            var steps = Math.min(animationStep, seekPos - currentOffset + 1);
+            var newOffset = currentOffset + steps;
 
-        this.trigger("seekDone");
+            for (; currentOffset < newOffset; currentOffset += 1) {
+                _this.runCommand(_this.commands[currentOffset]);
+                _this.cache(currentOffset);
+            }
+
+            if (currentOffset <= seekPos) {
+                window.requestAnimationFrame(buildCache);
+            } else {
+                _this.seeking = false;
+                _this.trigger("seekDone");
+            }
+        };
+
+        window.requestAnimationFrame(buildCache);
     },
 
     // Cache the result of the specified command
@@ -346,7 +375,7 @@ window.ScratchpadRecord = Backbone.Model.extend({
 
     play: function play() {
         // Don't play if we're already playing or recording
-        if (this.recording || this.playing || !this.commands || this.commands.length === 0) {
+        if (this.recording || this.playing || this.seeking || !this.commands || this.commands.length === 0) {
             return;
         }
 

--- a/js/output/webpage/webpage-output.js
+++ b/js/output/webpage/webpage-output.js
@@ -253,8 +253,7 @@ window.WebpageOutput = Backbone.View.extend({
 
         _.extend(this.tester.testContext, {
             $doc: $(this.frameDoc),
-            // Append to a div because jQuery doesn't work on a document fragment
-            $docSP: $("<div>").append(this.slowparseResults.document),
+            docSP: this.slowparseResults.document,
             cssRules: this.slowparseResults.rules
         });
 

--- a/js/output/webpage/webpage-tester.js
+++ b/js/output/webpage/webpage-tester.js
@@ -24,10 +24,10 @@
             var parser = new DOMParser();
             var doc = parser.parseFromString(userCode, "text/html");
 
-            $(doc).find("script").each(function (index, scriptElement) {
+            doc.querySelectorAll("script").forEach((scriptElement) => {
                 this.testContext.allScripts += scriptElement.innerHTML;
                 this.testContext.allScripts += "\n";
-            }.bind(this));
+            });
 
             this.curTask = null;
             this.curTest = null;
@@ -162,8 +162,8 @@
                 var expected = structure[selector];
                 // TODO(jeresig): Maybe find a way to do this such that we can run
                 // it in a worker thread.
-                var numFound = $(selector, this.testContext.$docSP).length;
-                if (expected === 0 && numFound !== 0 || numFound < expected) {
+                var numFound = this.testContext.docSP.querySelectorAll(selector).length;
+                if ((expected === 0 && numFound !== 0) || numFound < expected) {
                     return {success: false};
                 }
             }

--- a/tests/output/webpage/assert_test.js
+++ b/tests/output/webpage/assert_test.js
@@ -64,7 +64,8 @@ describe("Challenge Assertions - HTML", function() {
     assertTest({
         title: "Doing the step with no errors",
         code: "<p id='foo'><div></div></p>",
-        validate: divTest
+        validate: divTest,
+        fromTests: true
     });
 });
 
@@ -154,7 +155,8 @@ describe("Challenge Assertions - HTML Scripting", function() {
     assertTest({
         title: "jQuery scripting works",
         code: '<div><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script><script>$("img").animate({width:500});</script></div>',
-        validate: jQueryTest
+        validate: jQueryTest,
+        fromTests: true
     });
 });
 

--- a/tests/output/webpage/assert_test.js
+++ b/tests/output/webpage/assert_test.js
@@ -42,14 +42,16 @@ describe("Challenge Assertions - HTML", function() {
         title: "Failing to complete any step",
         code: "<span></span>",
         validate: divTest,
-        fromTests: true
+        fromTests: true,
+        reason: "fail"
     });
 
     assertTest({
         title: "Failing to complete any step",
         code: "<span></span>",
         validate: divTest,
-        fromTests: true
+        fromTests: true,
+        reason: "fail"
     });
 
     assertTest({
@@ -82,7 +84,8 @@ describe("Challenge Assertions - HTML Scripting", function() {
         title: "Scripting Works",
         code: "<div><script>window.x = 4;</script></div>",
         validate: xTest,
-    }); 
+        fromTests: true,
+    });
 
     assertTest({
         title: "Scripting Test fails",
@@ -170,20 +173,23 @@ describe("scriptTest tests", function() {
         title: "scriptTest reports success for matching code",
         code: "<div><script>var x = 4;</script></div>",
         validate: xTest,
-    }); 
+    });
 
     assertTest({
         title: "scriptTest reports failure for not matching code",
         code: "<div></div>",
         validate: xTest,
-        fromTests: true
+        fromTests: true,
+        reason: "fail"
     });
 
     assertTest({
         title: "scriptTest reports failure for not matching code",
         code: "<div><script>var y = 4;</script></div>",
         validate: xTest,
-    }); 
+        fromTests: true,
+        reason: "fail"
+    });
 });
 
 describe("CSS selector matching with wildcards", function() {
@@ -353,12 +359,12 @@ describe("Full CSS matching with wildcards", function() {
         css: "h1 { color: (0, 10, 20); }",
         callbacks: 'isValidColor("$1")'
     }, {
-        res: true, 
+        res: true,
         title: "Concatenating multiple stylesheets",
         pat: "h1{color: red} h2{color: black}",
-        html: "<style>h1{color: red}</style><style>h2{color: black}</style>", 
+        html: "<style>h1{color: red}</style><style>h2{color: black}</style>",
     }, {
-        res: false, 
+        res: false,
         title: "Later styles override earlier styles",
         pat: "h1{color: red}",
         html: "<style>h1{color: red}</style><style>h1{color: black}</style>"


### PR DESCRIPTION
### High-level description of change

This replaces jQuery with native DOM in WebpageTester (and an associated line in WebpageOutput).
I discovered that the tests weren't actually testing the results of the validation tests (as they were returning true even when my port was clearly faulty), so I also fixed the tests. 

### Are there performance implications for this change?

Teensy bit better due to not passing through jQuery.

### Have you added tests to cover this new/updated code?

I did not add tests, just fixed the existing ones and verified they went through the code path.

### Risks involved

Usual risk of jQuery to native, any differences.

### Are there any dependencies or blockers for merging this?

This PR has a build file from the PR that accidentally had no build files, so I should merge that first.

### How can we verify that this change works?

On KA, do a challenge in HTML/JS course, like https://www.khanacademy.org/computing/computer-programming/html-css-js/html-js-dom-access/p/challenge-query-modernizer
Verify you can pass and fail steps.