### PR TITLE
Add .gitattributes for ignoring build files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+build/* linguist-generated

--- a/build/js/live-editor.shared.js
+++ b/build/js/live-editor.shared.js
@@ -136,6 +136,10 @@ window.ScratchpadRecord = Backbone.Model.extend({
         // Array of command arrays for each chunk. Only holds chunks that
         // have been saved.
         this.allSavedCommands = [];
+
+        // True when we actively seeking to a new position and potentially
+        // building the cache.
+        this.seeking = false;
     },
 
     setActualInitData: function setActualInitData(actualData) {
@@ -256,6 +260,14 @@ window.ScratchpadRecord = Backbone.Model.extend({
     // Seek to a given position in the playback, executing all the
     // commands in the interim
     seekTo: function seekTo(time) {
+        var _this = this;
+
+        if (this.seeking) {
+            return;
+        }
+
+        this.seeking = true;
+
         // Initialize and seek to the desired position
         this.pauseTime = new Date().getTime();
         this.playStart = this.pauseTime - time;
@@ -303,13 +315,30 @@ window.ScratchpadRecord = Backbone.Model.extend({
             this.cacheRestore(-1 * this.seekCacheInterval);
         }
 
-        // Execute commands and build cache, bringing state up to current
-        for (var i = cacheOffset; i <= seekPos; i++) {
-            this.runCommand(this.commands[i]);
-            this.cache(i);
-        }
+        // To prevent the screen locking up while seeking ahead, processing
+        // commands, and building the cache, we can use requestAnimationFrame
+        // to process a few commands and cache entries, then see if we need to
+        // update the browser before processing another block of commands.
+        var currentOffset = cacheOffset;
+        var buildCache = function buildCache() {
+            var animationStep = 100;
+            var steps = Math.min(animationStep, seekPos - currentOffset + 1);
+            var newOffset = currentOffset + steps;
 
-        this.trigger("seekDone");
+            for (; currentOffset < newOffset; currentOffset += 1) {
+                _this.runCommand(_this.commands[currentOffset]);
+                _this.cache(currentOffset);
+            }
+
+            if (currentOffset <= seekPos) {
+                window.requestAnimationFrame(buildCache);
+            } else {
+                _this.seeking = false;
+                _this.trigger("seekDone");
+            }
+        };
+
+        window.requestAnimationFrame(buildCache);
     },
 
     // Cache the result of the specified command
@@ -346,7 +375,7 @@ window.ScratchpadRecord = Backbone.Model.extend({
 
     play: function play() {
         // Don't play if we're already playing or recording
-        if (this.recording || this.playing || !this.commands || this.commands.length === 0) {
+        if (this.recording || this.playing || this.seeking || !this.commands || this.commands.length === 0) {
             return;
         }
 


### PR DESCRIPTION
### High-level description of change

This uses .gitattributes to suppress the build files in the PR, for easier diff viewing.
See: https://robots.thoughtbot.com/github-diff-supression
and the WB usage: https://github.com/Khan/wonder-blocks/blob/master/.gitattributes

### Risks involved

If the build files change in an unexpected way, we are less likely to notice. The pre-commit script should help with that, however. (And generally, humans shouldn't be reviewing build files, so if build files do mess us up, that'll indicate an issue elsewhere in our system)

### Are there any dependencies or blockers for merging this?

I have to decide which PR to actually merge this un-built build file in. They've been awfully convenient for last two PRs! :) 

### How can we verify that this change works?

See below, notice that the build file is hidden by default with a notice.
(The diff notes still mentions build files, it'd be cool if it distinguished between the diff count for built vs unbuilt, so that my big PRs didn't look quite as big :)

