### PR TITLE
Use native DOM in PJSResourceCache

### DIFF
--- a/build/js/live-editor.output_pjs.js
+++ b/build/js/live-editor.output_pjs.js
@@ -2366,7 +2366,7 @@ PJSResourceCache.prototype.cacheResources = function (resources) {
     var promises = Object.keys(resources).map(function (filename) {
         return _this.loadResource(filename);
     });
-    return Promise.all(promises);
+    return $.when.apply($, promises);
 };
 
 PJSResourceCache.prototype.loadResource = function (filename) {

--- a/js/output/pjs/pjs-resource-cache.js
+++ b/js/output/pjs/pjs-resource-cache.js
@@ -13,15 +13,6 @@ function PJSResourceCache(options) {
         this.imageHolder.style.overflow = "hidden";
         this.imageHolder.style.position = "absolute";
         document.body.appendChild(this.imageHolder);
-
-        this.imageHolder = $("<div>")
-            .css({
-                height: 0,
-                width: 0,
-                overflow: "hidden",
-                position: "absolute"
-            })
-            .appendTo("body");
     }
 }
 
@@ -52,52 +43,53 @@ PJSResourceCache.prototype.loadResource = function(filename) {
 };
 
 PJSResourceCache.prototype.loadImage = function(filename) {
-    return new Promise((resolve) => {
-        var path = this.output.imagesDir + filename;
-        var img = document.createElement("img");
+    var deferred = $.Deferred();
+    var path = this.output.imagesDir + filename;
+    var img = document.createElement("img");
 
-        img.onload = function() {
-            this.cache[filename] = img;
-            resolve();
-        }.bind(this);
-        img.onerror = function() {
-            resolve(); // always resolve
-        }.bind(this);
+    img.onload = function() {
+        this.cache[filename] = img;
+        deferred.resolve();
+    }.bind(this);
+    img.onerror = function() {
+        deferred.resolve(); // always resolve
+    }.bind(this);
 
-        img.src = path;
-        this.imageHolder.append(img);
-    });
+    img.src = path;
+    this.imageHolder.appendChild(img);
+
+    return deferred;
 };
 
 PJSResourceCache.prototype.loadSound = function(filename) {
-    return new Promise((resolve) => {
-        var audio = document.createElement("audio");
-        var parts = filename.split("/");
+    var deferred = $.Deferred();
+    var audio = document.createElement("audio");
+    var parts = filename.split("/");
 
-        var group = _.findWhere(OutputSounds[0].groups, { groupName: parts[0] });
-        var hasSound = group && group.sounds.includes(parts[1].replace(".mp3", ""));
+    var group = _.findWhere(OutputSounds[0].groups, { groupName: parts[0] });
+    var hasSound = group && group.sounds.includes(parts[1].replace(".mp3", ""));
+    if (!hasSound) {
+        deferred.resolve();
+        return deferred;
+    }
 
-        if (!hasSound) {
-            resolve();
-            return;
-        }
+    audio.preload = "auto";
+    audio.oncanplaythrough = function() {
+        this.cache[filename] = {
+            audio: audio,
+            __id: function () {
+                return `getSound('${filename.replace(".mp3", "")}')`;
+            }
+        };
+        deferred.resolve();
+    }.bind(this);
+    audio.onerror = function() {
+        deferred.resolve();
+    }.bind(this);
 
-        audio.preload = "auto";
-        audio.oncanplaythrough = function() {
-            this.cache[filename] = {
-                audio: audio,
-                __id: function () {
-                    return `getSound('${filename.replace(".mp3", "")}')`;
-                }
-            };
-            resolve();
-        }.bind(this);
-        audio.onerror = function() {
-            resolve();
-        }.bind(this);
+    audio.src = this.output.soundsDir + filename;
 
-        audio.src = this.output.soundsDir + filename;
-    });
+    return deferred;
 };
 
 PJSResourceCache.prototype.getResource = function(filename, type) {

--- a/js/output/pjs/pjs-resource-cache.js
+++ b/js/output/pjs/pjs-resource-cache.js
@@ -31,7 +31,7 @@ PJSResourceCache.prototype.cacheResources = function(resources) {
     var promises = Object.keys(resources).map((filename) => {
         return this.loadResource(filename);
     });
-    return Promise.all(promises);
+    return $.when.apply($, promises);
 };
 
 PJSResourceCache.prototype.loadResource = function(filename) {


### PR DESCRIPTION
### High-level description of change

This replaces jQuery with native DOM in PJSResourceCache.
(It leaves $.Deferred, as that requires a promise-polyfill, so that will be a separate PR).

I verified by inspecting the created <div> and the network requests.

### Are there performance implications for this change?

Teensy bit better.

### Have you added tests to cover this new/updated code?

No.

### Risks involved

None forseen.

### Are there any dependencies or blockers for merging this?

No.

### How can we verify that this change works?

Put code like this in a program:
image(getImage("avatars/leaf-orange"), 10, 20);
playSound(getSound("rpg/metal-clink"));
You should see the resources loaded immediately when you load the program page, and no 404 errors in console.
