### PR TITLE
Replace deferreds with Promise in PJSCodeInjector and PJSResourceCache

### DIFF
--- a/build/js/live-editor.output_pjs.js
+++ b/build/js/live-editor.output_pjs.js
@@ -376,38 +376,37 @@ var PJSCodeInjector = (function () {
          *
          * @param {string} userCode: code to lint
          * @param {boolean} skip: skips linting if true and resolves Deferred immediately
-         * @returns {$.Deferred} resolves an array of lint errors
+         * @returns {Promise} resolves an array of lint errors
          */
         value: function lint(userCode, skip) {
             var _this3 = this;
 
-            var deferred = $.Deferred();
-            if (skip || !userCode) {
-                deferred.resolve([]);
-                return deferred;
-            }
+            return new Promise(function (resolve) {
+                if (skip || !userCode) {
+                    resolve([]);
+                    return;
+                }
 
-            // Build a string of options to feed into JSHint
-            // All properties are defined in the config
-            var hintCode = "/*jshint " + this.propListString(this.JSHint) + " */" + (
+                // Build a string of options to feed into JSHint
+                // All properties are defined in the config
+                var hintCode = "/*jshint " + _this3.propListString(_this3.JSHint) + " */" + (
 
-            // Build a string of variables names to feed into JSHint
-            // This lets JSHint know which variables are globally exposed
-            // and which can be overridden, more details:
-            // http://www.jshint.com/about/
-            // propName: true (is a global property, but can be overridden)
-            // propName: false (is a global property, cannot be overridden)
-            "/*global " + this.propListString(this.props) + " */\n") +
+                // Build a string of variables names to feed into JSHint
+                // This lets JSHint know which variables are globally exposed
+                // and which can be overridden, more details:
+                // http://www.jshint.com/about/
+                // propName: true (is a global property, but can be overridden)
+                // propName: false (is a global property, cannot be overridden)
+                "/*global " + _this3.propListString(_this3.props) + " */\n") +
 
-            // The user's code to execute
-            userCode;
+                // The user's code to execute
+                userCode;
 
-            this.hintWorker.exec(hintCode, function (hintData, hintErrors) {
-                _this3.globals = _this3.extractGlobals(hintData);
-                deferred.resolve(hintErrors);
+                _this3.hintWorker.exec(hintCode, function (hintData, hintErrors) {
+                    _this3.globals = _this3.extractGlobals(hintData);
+                    resolve(hintErrors);
+                });
             });
-
-            return deferred;
         }
     }, {
         key: "extractGlobals",
@@ -455,9 +454,9 @@ var PJSCodeInjector = (function () {
             // Make sure the object actually exists before we try
             // to inject stuff into it
             if (!this.processing[name]) {
-                if ($.isArray(obj)) {
+                if (Array.isArray(obj)) {
                     this.processing[name] = [];
-                } else if ($.isFunction(obj)) {
+                } else if (typeof obj === "function") {
                     this.processing[name] = function () {};
                 } else {
                     this.processing[name] = {};
@@ -1106,46 +1105,44 @@ var PJSCodeInjector = (function () {
                 document.body.appendChild(imageHolder);
 
                 var loadImage = function loadImage(filename) {
-                    var deferred = $.Deferred();
-                    var img = document.createElement("img");
-                    img.onload = (function () {
+                    return new Promise(function (resolve) {
+                        var img = document.createElement("img");
+                        img.onload = function () {
+                            resourceCache[filename] = img;
+                            resolve();
+                        };
+                        img.onerror = function () {
+                            resolve(); // always resolve
+                        };
+
+                        img.src = imageDir + filename;
+                        imageHolder.appendChild(img);
                         resourceCache[filename] = img;
-                        deferred.resolve();
-                    }).bind(this);
-                    img.onerror = (function () {
-                        deferred.resolve(); // always resolve
-                    }).bind(this);
-
-                    img.src = imageDir + filename;
-                    imageHolder.appendChild(img);
-                    resourceCache[filename] = img;
-
-                    return deferred.promise();
+                    });
                 };
 
                 var loadSound = function loadSound(filename) {
-                    var deferred = $.Deferred();
-                    var audio = document.createElement("audio");
-                    var parts = filename.split("/");
+                    return new Promise(function (resolve) {
+                        var audio = document.createElement("audio");
+                        var parts = filename.split("/");
 
-                    var group = _.findWhere(OutputSounds[0].groups, { groupName: parts[0] });
-                    if (!group || group.sounds.indexOf(parts[1].replace(".mp3", "")) === -1) {
-                        deferred.resolve();
-                        return deferred;
-                    }
+                        var group = _.findWhere(OutputSounds[0].groups, { groupName: parts[0] });
+                        if (!group || group.sounds.indexOf(parts[1].replace(".mp3", "")) === -1) {
+                            resolve();
+                            return;
+                        }
 
-                    audio.preload = "auto";
-                    audio.oncanplaythrough = (function () {
-                        resourceCache[filename] = audio;
-                        deferred.resolve();
-                    }).bind(this);
-                    audio.onerror = (function () {
-                        deferred.resolve();
-                    }).bind(this);
+                        audio.preload = "auto";
+                        audio.oncanplaythrough = function () {
+                            resourceCache[filename] = audio;
+                            resolve();
+                        };
+                        audio.onerror = function () {
+                            resolve();
+                        };
 
-                    audio.src = soundDir + filename;
-
-                    return deferred;
+                        audio.src = soundDir + filename;
+                    });
                 };
 
                 var promises = Object.keys(resources).map(function (filename) {
@@ -1156,7 +1153,7 @@ var PJSCodeInjector = (function () {
                     }
                 });
 
-                $.when.apply($, promises).then(function () {
+                Promise.all(promises).then(function () {
                     var canvas = document.createElement("canvas");
                     canvas.width = 400;
                     canvas.height = 400;
@@ -2491,7 +2488,7 @@ PJSResourceCache.prototype.cacheResources = function (resources) {
     var promises = Object.keys(resources).map(function (filename) {
         return _this.loadResource(filename);
     });
-    return $.when.apply($, promises);
+    return Promise.all(promises);
 };
 
 PJSResourceCache.prototype.loadResource = function (filename) {
@@ -2503,53 +2500,55 @@ PJSResourceCache.prototype.loadResource = function (filename) {
 };
 
 PJSResourceCache.prototype.loadImage = function (filename) {
-    var deferred = $.Deferred();
-    var path = this.output.imagesDir + filename;
-    var img = document.createElement("img");
+    var _this2 = this;
 
-    img.onload = (function () {
-        this.cache[filename] = img;
-        deferred.resolve();
-    }).bind(this);
-    img.onerror = (function () {
-        deferred.resolve(); // always resolve
-    }).bind(this);
+    return new Promise(function (resolve) {
+        var path = _this2.output.imagesDir + filename;
+        var img = document.createElement("img");
 
-    img.src = path;
-    this.imageHolder.appendChild(img);
+        img.onload = function () {
+            _this2.cache[filename] = img;
+            resolve();
+        };
+        img.onerror = function () {
+            resolve(); // always resolve
+        };
 
-    return deferred;
+        img.src = path;
+        _this2.imageHolder.appendChild(img);
+    });
 };
 
 PJSResourceCache.prototype.loadSound = function (filename) {
-    var deferred = $.Deferred();
-    var audio = document.createElement("audio");
-    var parts = filename.split("/");
+    var _this3 = this;
 
-    var group = _.findWhere(OutputSounds[0].groups, { groupName: parts[0] });
-    var hasSound = group && group.sounds.includes(parts[1].replace(".mp3", ""));
-    if (!hasSound) {
-        deferred.resolve();
-        return deferred;
-    }
+    return new Promise(function (resolve) {
+        var audio = document.createElement("audio");
+        var parts = filename.split("/");
 
-    audio.preload = "auto";
-    audio.oncanplaythrough = (function () {
-        this.cache[filename] = {
-            audio: audio,
-            __id: function __id() {
-                return "getSound('" + filename.replace(".mp3", "") + "')";
-            }
+        var group = _.findWhere(OutputSounds[0].groups, { groupName: parts[0] });
+        var hasSound = group && group.sounds.includes(parts[1].replace(".mp3", ""));
+        if (!hasSound) {
+            resolve();
+            return;
+        }
+
+        audio.preload = "auto";
+        audio.oncanplaythrough = function () {
+            _this3.cache[filename] = {
+                audio: audio,
+                __id: function __id() {
+                    return "getSound('" + filename.replace(".mp3", "") + "')";
+                }
+            };
+            resolve();
         };
-        deferred.resolve();
-    }).bind(this);
-    audio.onerror = (function () {
-        deferred.resolve();
-    }).bind(this);
+        audio.onerror = function () {
+            resolve();
+        };
 
-    audio.src = this.output.soundsDir + filename;
-
-    return deferred;
+        audio.src = _this3.output.soundsDir + filename;
+    });
 };
 
 PJSResourceCache.prototype.getResource = function (filename, type) {


### PR DESCRIPTION
### High-level description of change

This PR replaces Deferreds with Promise in PJSResourceCache and PJSCodeInjector (which is basically the same code in both, we have a TODO about DRYing it).

This is part of the effort to modernize LiveEditor so that it's easy to port to webpack/React without jQuery dependencies.

Live-editor currently has "babel-core/browser-polyfill.min.js", and from what I can tell, that adds a polyfill for Promises across browsers. If you know differently, let me know!

### Are there performance implications for this change?

Teensy bit better, less jQuery middleman.

### Have you added tests to cover this new/updated code?

No, I ran the existing tests and used getImage() in the demo. They error'ed when I had a bug in the code, so they seem to work!

### Risks involved

If the polyfill doesn't work in all the browsers, that will be a problem.

### Are there any dependencies or blockers for merging this?

No

### How can we verify that this change works?

Load some media:
image(getImage("avatars/marcimus-orange"), 10, 10);
playSound(getSound("rpg/metal-clink"));