### PR TITLE
Fix #542

### DIFF
--- a/build/js/live-editor.output_pjs.js
+++ b/build/js/live-editor.output_pjs.js
@@ -2311,16 +2311,17 @@ var BabyHint = {
         };
 
         var stack = [];
+        var indexStack = [];
         var commaCount = 0;
-        var lastPushIndex = 0;
 
         for (var i = 0; i < str.length; i++) {
             if (pairs.hasOwnProperty(str[i])) {
                 stack.push(str[i]);
-                lastPushIndex = i;
+                indexStack.push(i);
             } else if (revPairs.hasOwnProperty(str[i])) {
                 if (revPairs[str[i]] === stack[stack.length - 1]) {
                     stack.pop();
+                    indexStack.pop();
                 } else {
                     return {
                         error: {
@@ -2337,7 +2338,7 @@ var BabyHint = {
         return stack.length > 0 ? {
             error: {
                 message: i18n._("Unmatched \"%(token)s\"", { token: stack.pop() }),
-                index: lastPushIndex
+                index: indexStack.pop()
             }
         } : {
             count: commaCount

--- a/build/js/live-editor.output_pjs.js
+++ b/build/js/live-editor.output_pjs.js
@@ -2298,6 +2298,52 @@ var BabyHint = {
         return variables;
     },
 
+    countCommas: function countCommas(str) {
+        var pairs = {
+            "(": ")",
+            "{": "}",
+            "[": "]"
+        },
+            revPairs = {
+            ")": "(",
+            "}": "{",
+            "]": "["
+        };
+
+        var stack = [];
+        var commaCount = 0;
+        var lastPushIndex = 0;
+
+        for (var i = 0; i < str.length; i++) {
+            if (pairs.hasOwnProperty(str[i])) {
+                stack.push(str[i]);
+                lastPushIndex = i;
+            } else if (revPairs.hasOwnProperty(str[i])) {
+                if (revPairs[str[i]] === stack[stack.length - 1]) {
+                    stack.pop();
+                } else {
+                    return {
+                        error: {
+                            message: i18n._("Unexpected \"%(token)s\"", { token: str[i] }),
+                            index: i
+                        }
+                    };
+                }
+            } else if (stack.length === 0 && str[i] === ",") {
+                commaCount++;
+            }
+        }
+
+        return stack.length > 0 ? {
+            error: {
+                message: i18n._("Unmatched \"%(token)s\"", { token: stack.pop() }),
+                index: lastPushIndex
+            }
+        } : {
+            count: commaCount
+        };
+    },
+
     checkFunctionParams: function checkFunctionParams(line, lineNumber) {
         // Many Processing functions don't break if passed the wrong
         // number of parameters, but they also don't work.
@@ -2392,10 +2438,24 @@ var BabyHint = {
             }
 
             // count the parameters passed
-            var numParams;
-            var numCommas = params.match(/,/g);
-            if (numCommas) {
-                numParams = numCommas.length + 1;
+            var numParams,
+                rawCount = this.countCommas(params.substring(1, params.length - 1));
+
+            // push in an error if an error occurs while parsing the param list
+            if (rawCount.error) {
+                errors.push({
+                    row: lineNumber,
+                    column: index + 2 + rawCount.error.index,
+                    text: rawCount.error.message,
+                    breaksCode: false,
+                    source: "paramschecker",
+                    context: {}
+                });
+                return errors;
+            }
+
+            if (rawCount.count) {
+                numParams = rawCount.count + 1;
             } else {
                 numParams = params.match(/[^\s()]/g) ? 1 : 0;
             }

--- a/js/output/pjs/babyhint.js
+++ b/js/output/pjs/babyhint.js
@@ -559,16 +559,17 @@ var BabyHint = {
         };
 
         var stack = [];
+        var indexStack = [];
         var commaCount = 0;
-        var lastPushIndex = 0;
 
         for (var i = 0; i < str.length; i++) {
             if (pairs.hasOwnProperty(str[i])) {
                 stack.push(str[i]);
-                lastPushIndex = i;
+                indexStack.push(i);
             } else if (revPairs.hasOwnProperty(str[i])) {
                 if (revPairs[str[i]] === stack[stack.length - 1]) {
                     stack.pop();
+                    indexStack.pop();
                 } else {
                     return {
                         error: {
@@ -585,7 +586,7 @@ var BabyHint = {
         return stack.length > 0 ? {
             error: {
                 message: i18n._("Unmatched \"%(token)s\"", { token: stack.pop() }),
-                index: lastPushIndex
+                index: indexStack.pop()
             }
         } : {
             count: commaCount

--- a/js/output/pjs/babyhint.js
+++ b/js/output/pjs/babyhint.js
@@ -547,6 +547,51 @@ var BabyHint = {
         return variables;
     },
 
+    countCommas: function(str) {
+        var pairs = {
+            "(": ")",
+            "{": "}",
+            "[": "]"
+        }, revPairs = {
+            ")": "(",
+            "}": "{",
+            "]": "["
+        };
+
+        var stack = [];
+        var commaCount = 0;
+        var lastPushIndex = 0;
+
+        for (var i = 0; i < str.length; i++) {
+            if (pairs.hasOwnProperty(str[i])) {
+                stack.push(str[i]);
+                lastPushIndex = i;
+            } else if (revPairs.hasOwnProperty(str[i])) {
+                if (revPairs[str[i]] === stack[stack.length - 1]) {
+                    stack.pop();
+                } else {
+                    return {
+                        error: {
+                            message: i18n._("Unexpected \"%(token)s\"", { token: str[i] }),
+                            index: i
+                        }
+                    };
+                }
+            } else if (stack.length === 0 && str[i] === ",") {
+                commaCount++;
+            }
+        }
+
+        return stack.length > 0 ? {
+            error: {
+                message: i18n._("Unmatched \"%(token)s\"", { token: stack.pop() }),
+                index: lastPushIndex
+            }
+        } : {
+            count: commaCount
+        };
+    },
+
     checkFunctionParams: function(line, lineNumber) {
         // Many Processing functions don't break if passed the wrong
         // number of parameters, but they also don't work.
@@ -641,10 +686,23 @@ var BabyHint = {
             }
 
             // count the parameters passed
-            var numParams;
-            var numCommas = params.match(/,/g);
-            if (numCommas) {
-                numParams = numCommas.length + 1;
+            var numParams, rawCount = this.countCommas(params.substring(1, params.length - 1));
+
+            // push in an error if an error occurs while parsing the param list
+            if (rawCount.error) {
+                errors.push({
+                    row: lineNumber,
+                    column: index + 2 + rawCount.error.index,
+                    text: rawCount.error.message,
+                    breaksCode: false,
+                    source: "paramschecker",
+                    context: {}
+                });
+                return errors;
+            }
+
+            if (rawCount.count) {
+                numParams = rawCount.count + 1;
             } else {
                 numParams = params.match(/[^\s()]/g) ? 1 : 0;
             }

--- a/tests/output/pjs/jshint_test.js
+++ b/tests/output/pjs/jshint_test.js
@@ -108,6 +108,32 @@ describe("Scratchpad Output - BabyHint checks", function() {
         babyhint: true,
         code: "rect(100, 200, 300);"
     });
+
+    assertTest({
+        title: "Too few arguments (proper comma detection)",
+        reason: "\"rect()\" takes 4, 5 or 8 parameters, not 2!",
+        babyhint: true,
+        code: "rect([0, 2, 3][0], 20);"
+    })
+
+    assertTest({
+        title: "println array argument (should pass)",
+        babyhint: true,
+        code: "println([3, 2, 1]);"
+    })
+
+    assertTest({
+        title: "text with a nested object/array argument (should pass)",
+        babyhint: true,
+        code: "text({ a: 10, b: [1, 2, 3], c: \")\" }, 10, 20);"
+    })
+
+    assertTest({
+        title: "ellipse with parenthesized expression arg",
+        reason: "\"ellipse()\" takes 4 parameters, not 3!",
+        babyhint: true,
+        code: "ellipse(100, 100, (10, 20));"
+    })
 });
 
 // Syntax errors - not controlled by JSHint options.


### PR DESCRIPTION
### High-level description of change
This change makes it so that Babyhint accurately counts the number of arguments passed into a function.  Fixes #542.

### Are there performance implications for this change?
`countCommas` might not be as fast as `match(/,/g)`.

### Have you added tests to cover this new/updated code?
Yes.  The tests I added are present in `jshint_test.js`.

### Risks involved
I can't think of any risks involved with this PR.

### Are there any dependencies or blockers for merging this?
No.

### How can we verify that this change works?
I added tests.
