### PR TITLE
Normalizing console statements, removing window

### DIFF
--- a/build/js/live-editor.output.js
+++ b/build/js/live-editor.output.js
@@ -85,7 +85,7 @@ OutputTester.prototype = {
             try {
                 tester.exec(validate);
             } catch (e) {
-                console && console.warn(e.message);
+                console.warn(e.message);
                 return;
             }
 
@@ -206,7 +206,7 @@ OutputTester.prototype = {
                     try {
                         return _fn.apply(this, arguments);
                     } catch (e) {
-                        console && console.warn(e);
+                        console.warn(e);
                     }
                 }
             });

--- a/build/js/live-editor.output.js
+++ b/build/js/live-editor.output.js
@@ -85,9 +85,7 @@ OutputTester.prototype = {
             try {
                 tester.exec(validate);
             } catch (e) {
-                if (window.console) {
-                    console.warn(e.message);
-                }
+                console && console.warn(e.message);
                 return;
             }
 
@@ -208,9 +206,7 @@ OutputTester.prototype = {
                     try {
                         return _fn.apply(this, arguments);
                     } catch (e) {
-                        if (window.console) {
-                            console.warn(e);
-                        }
+                        console && console.warn(e);
                     }
                 }
             });

--- a/build/js/live-editor.output_pjs.js
+++ b/build/js/live-editor.output_pjs.js
@@ -1719,9 +1719,7 @@ PJSTester.prototype.testMethods = {
                 message: callbacks && callbacks.failure
             };
         } catch (e) {
-            if (window.console) {
-                console.warn(e);
-            }
+            console && console.warn(e);
             return {
                 success: true,
                 message: i18n._("Hm, we're having some trouble " + "verifying your answer for this step, so we'll give " + "you the benefit of the doubt as we work to fix it. " + "Please click \"Report a problem\" to notify us.")
@@ -3020,8 +3018,7 @@ window.PJSOutput = Backbone.View.extend({
                 // translated text "A critical problem occurred..." to
                 // figure out whether we hit this case.
                 var message = i18n._("Error: %(message)s", { message: errors[errors.length - 1].message });
-                // TODO(jeresig): Find a better way to show this
-                this.output.$el.find(".test-errors").text(message).show();
+                console && console.warn(message);
                 this.tester.testContext.assert(false, message, i18n._("A critical problem occurred in your program " + "making it unable to run."));
             }
 

--- a/build/js/live-editor.output_pjs.js
+++ b/build/js/live-editor.output_pjs.js
@@ -1719,7 +1719,7 @@ PJSTester.prototype.testMethods = {
                 message: callbacks && callbacks.failure
             };
         } catch (e) {
-            console && console.warn(e);
+            console.warn(e);
             return {
                 success: true,
                 message: i18n._("Hm, we're having some trouble " + "verifying your answer for this step, so we'll give " + "you the benefit of the doubt as we work to fix it. " + "Please click \"Report a problem\" to notify us.")
@@ -3018,7 +3018,7 @@ window.PJSOutput = Backbone.View.extend({
                 // translated text "A critical problem occurred..." to
                 // figure out whether we hit this case.
                 var message = i18n._("Error: %(message)s", { message: errors[errors.length - 1].message });
-                console && console.warn(message);
+                console.warn(message);
                 this.tester.testContext.assert(false, message, i18n._("A critical problem occurred in your program " + "making it unable to run."));
             }
 

--- a/build/js/live-editor.output_sql.js
+++ b/build/js/live-editor.output_sql.js
@@ -325,9 +325,7 @@ SQLTester.prototype.testMethods = {
 
         for (var key in params) {
             if (params[key][0] !== "$") {
-                if (window.console) {
-                    console.warn("Invalid parameter in constraint " + "(should begin with a '$'): ", params[key]);
-                }
+                console && console.warn("Invalid parameter in constraint " + "(should begin with a '$'): ", params[key]);
                 return null;
             }
         }
@@ -445,7 +443,7 @@ SQLTester.prototype.testMethods = {
     },
 
     /**
-     * @param templateDBInfo: A template DB to match column names 
+     * @param templateDBInfo: A template DB to match column names
      * @return {success} if user table contains same column names
      *   Note - it could also contain other names,
      *   use matchTableColumnCount if you need to be exact.
@@ -986,8 +984,7 @@ window.SQLOutput = Backbone.View.extend({
                 // translated text "A critical problem occurred..." to
                 // figure out whether we hit this case.
                 var message = i18n._("Error: %(message)s", { message: errors[errors.length - 1].message });
-                // TODO(jeresig): Find a better way to show this
-                this.output.$el.find(".test-errors").text(message).show();
+                console && console.warn(message);
                 this.tester.testContext.assert(false, message, i18n._("A critical problem occurred in your program " + "making it unable to run."));
             }
 

--- a/build/js/live-editor.output_sql.js
+++ b/build/js/live-editor.output_sql.js
@@ -325,7 +325,7 @@ SQLTester.prototype.testMethods = {
 
         for (var key in params) {
             if (params[key][0] !== "$") {
-                console && console.warn("Invalid parameter in constraint " + "(should begin with a '$'): ", params[key]);
+                console.warn("Invalid parameter in constraint " + "(should begin with a '$'): ", params[key]);
                 return null;
             }
         }
@@ -984,7 +984,7 @@ window.SQLOutput = Backbone.View.extend({
                 // translated text "A critical problem occurred..." to
                 // figure out whether we hit this case.
                 var message = i18n._("Error: %(message)s", { message: errors[errors.length - 1].message });
-                console && console.warn(message);
+                console.warn(message);
                 this.tester.testContext.assert(false, message, i18n._("A critical problem occurred in your program " + "making it unable to run."));
             }
 

--- a/build/js/live-editor.output_webpage.js
+++ b/build/js/live-editor.output_webpage.js
@@ -123,7 +123,7 @@
 
                 for (var key in variables) {
                     if (variables[key][0] !== "$") {
-                        console && console.warn("Invalid variable in constraint (should begin with a '$'): ", variables[key]);
+                        console.warn("Invalid variable in constraint (should begin with a '$'): ", variables[key]);
                         return null;
                     }
                 }
@@ -542,7 +542,7 @@
                     message: callbacks && callbacks.failure
                 };
             } catch (e) {
-                console && console.warn(e);
+                console.warn(e);
                 return {
                     success: true,
                     message: i18n._("Hm, we're having some trouble " + "verifying your answer for this step, so we'll give " + "you the benefit of the doubt as we work to fix it. " + "Please click \"Report a problem\" to notify us.")
@@ -664,7 +664,7 @@ window.WebpageOutput = Backbone.View.extend({
                 disableTags: ["iframe", "embed", "object", "frameset", "frame"]
             });
         } catch (e) {
-            console && console.warn(e);
+            console.warn(e);
             results.error = {
                 type: "UNKNOWN_SLOWPARSE_ERROR"
             };
@@ -811,7 +811,7 @@ window.WebpageOutput = Backbone.View.extend({
                 // translated text "A critical problem occurred..." to
                 // figure out whether we hit this case.
                 var message = i18n._("Error: %(message)s", { message: errors[errors.length - 1].message });
-                console && console.warn(message);
+                console.warn(message);
                 this.tester.testContext.assert(false, message, i18n._("A critical problem occurred in your program " + "making it unable to run."));
             }
 

--- a/build/js/live-editor.output_webpage.js
+++ b/build/js/live-editor.output_webpage.js
@@ -123,7 +123,7 @@
 
                 for (var key in variables) {
                     if (variables[key][0] !== "$") {
-                        console.warn("Invalid variable in constraint (should begin with a '$'): ", variables[key]);
+                        console && console.warn("Invalid variable in constraint (should begin with a '$'): ", variables[key]);
                         return null;
                     }
                 }
@@ -542,9 +542,7 @@
                     message: callbacks && callbacks.failure
                 };
             } catch (e) {
-                if (window.console) {
-                    console.warn(e);
-                }
+                console && console.warn(e);
                 return {
                     success: true,
                     message: i18n._("Hm, we're having some trouble " + "verifying your answer for this step, so we'll give " + "you the benefit of the doubt as we work to fix it. " + "Please click \"Report a problem\" to notify us.")
@@ -666,9 +664,7 @@ window.WebpageOutput = Backbone.View.extend({
                 disableTags: ["iframe", "embed", "object", "frameset", "frame"]
             });
         } catch (e) {
-            if (window.console) {
-                console.warn(e);
-            }
+            console && console.warn(e);
             results.error = {
                 type: "UNKNOWN_SLOWPARSE_ERROR"
             };
@@ -815,8 +811,7 @@ window.WebpageOutput = Backbone.View.extend({
                 // translated text "A critical problem occurred..." to
                 // figure out whether we hit this case.
                 var message = i18n._("Error: %(message)s", { message: errors[errors.length - 1].message });
-                // TODO(jeresig): Find a better way to show this
-                this.output.$el.find(".test-errors").text(message).show();
+                console && console.warn(message);
                 this.tester.testContext.assert(false, message, i18n._("A critical problem occurred in your program " + "making it unable to run."));
             }
 

--- a/build/js/live-editor.output_webpage_deps.js
+++ b/build/js/live-editor.output_webpage_deps.js
@@ -13430,7 +13430,7 @@ PJSTester.prototype.testMethods = {
                 message: callbacks && callbacks.failure
             };
         } catch (e) {
-            console && console.warn(e);
+            console.warn(e);
             return {
                 success: true,
                 message: i18n._("Hm, we're having some trouble " + "verifying your answer for this step, so we'll give " + "you the benefit of the doubt as we work to fix it. " + "Please click \"Report a problem\" to notify us.")

--- a/build/js/live-editor.output_webpage_deps.js
+++ b/build/js/live-editor.output_webpage_deps.js
@@ -13430,9 +13430,7 @@ PJSTester.prototype.testMethods = {
                 message: callbacks && callbacks.failure
             };
         } catch (e) {
-            if (window.console) {
-                console.warn(e);
-            }
+            console && console.warn(e);
             return {
                 success: true,
                 message: i18n._("Hm, we're having some trouble " + "verifying your answer for this step, so we'll give " + "you the benefit of the doubt as we work to fix it. " + "Please click \"Report a problem\" to notify us.")

--- a/build/workers/pjs/pjs-tester.js
+++ b/build/workers/pjs/pjs-tester.js
@@ -373,7 +373,7 @@ PJSTester.prototype.testMethods = {
                 message: callbacks && callbacks.failure
             };
         } catch (e) {
-            console && console.warn(e);
+            console.warn(e);
             return {
                 success: true,
                 message: i18n._("Hm, we're having some trouble " +

--- a/build/workers/pjs/pjs-tester.js
+++ b/build/workers/pjs/pjs-tester.js
@@ -373,9 +373,7 @@ PJSTester.prototype.testMethods = {
                 message: callbacks && callbacks.failure
             };
         } catch (e) {
-            if (window.console) {
-                console.warn(e);
-            }
+            console && console.warn(e);
             return {
                 success: true,
                 message: i18n._("Hm, we're having some trouble " +
@@ -395,7 +393,7 @@ PJSTester.prototype.testMethods = {
         }
         return this.testContext.match(structure).success;
     },
-            
+
     _checkSyntaxErrors: function(syntaxChecks) {
         if (!syntaxChecks) return;
 

--- a/build/workers/shared/output-tester.js
+++ b/build/workers/shared/output-tester.js
@@ -37,7 +37,7 @@ OutputTester.prototype = {
                 try {
                     tester.exec(validate);
                 } catch(e) {
-                    console && console.warn(e.message);
+                    console.warn(e.message);
                     return;
                 }
 
@@ -159,7 +159,7 @@ OutputTester.prototype = {
                     try {
                         return fn.apply(this, arguments);
                     } catch (e) {
-                        console && console.warn(e);
+                        console.warn(e);
                     }
                 }
             });

--- a/build/workers/shared/output-tester.js
+++ b/build/workers/shared/output-tester.js
@@ -37,9 +37,7 @@ OutputTester.prototype = {
                 try {
                     tester.exec(validate);
                 } catch(e) {
-                    if (window.console) {
-                        console.warn(e.message);
-                    }
+                    console && console.warn(e.message);
                     return;
                 }
 
@@ -161,9 +159,7 @@ OutputTester.prototype = {
                     try {
                         return fn.apply(this, arguments);
                     } catch (e) {
-                        if (window.console) {
-                            console.warn(e);
-                        }
+                        console && console.warn(e);
                     }
                 }
             });

--- a/js/output/pjs/pjs-output.js
+++ b/js/output/pjs/pjs-output.js
@@ -437,7 +437,7 @@ window.PJSOutput = Backbone.View.extend({
                     // figure out whether we hit this case.
                     var message = i18n._("Error: %(message)s",
                         {message: errors[errors.length - 1].message});
-                    console && console.warn(message);
+                    console.warn(message);
                     this.tester.testContext.assert(false, message,
                         i18n._("A critical problem occurred in your program " +
                             "making it unable to run."));

--- a/js/output/pjs/pjs-output.js
+++ b/js/output/pjs/pjs-output.js
@@ -437,8 +437,7 @@ window.PJSOutput = Backbone.View.extend({
                     // figure out whether we hit this case.
                     var message = i18n._("Error: %(message)s",
                         {message: errors[errors.length - 1].message});
-                    // TODO(jeresig): Find a better way to show this
-                    this.output.$el.find(".test-errors").text(message).show();
+                    console && console.warn(message);
                     this.tester.testContext.assert(false, message,
                         i18n._("A critical problem occurred in your program " +
                             "making it unable to run."));

--- a/js/output/pjs/pjs-tester.js
+++ b/js/output/pjs/pjs-tester.js
@@ -373,7 +373,7 @@ PJSTester.prototype.testMethods = {
                 message: callbacks && callbacks.failure
             };
         } catch (e) {
-            console && console.warn(e);
+            console.warn(e);
             return {
                 success: true,
                 message: i18n._("Hm, we're having some trouble " +

--- a/js/output/pjs/pjs-tester.js
+++ b/js/output/pjs/pjs-tester.js
@@ -373,9 +373,7 @@ PJSTester.prototype.testMethods = {
                 message: callbacks && callbacks.failure
             };
         } catch (e) {
-            if (window.console) {
-                console.warn(e);
-            }
+            console && console.warn(e);
             return {
                 success: true,
                 message: i18n._("Hm, we're having some trouble " +
@@ -395,7 +393,7 @@ PJSTester.prototype.testMethods = {
         }
         return this.testContext.match(structure).success;
     },
-            
+
     _checkSyntaxErrors: function(syntaxChecks) {
         if (!syntaxChecks) return;
 

--- a/js/output/shared/output-tester.js
+++ b/js/output/shared/output-tester.js
@@ -37,7 +37,7 @@ OutputTester.prototype = {
                 try {
                     tester.exec(validate);
                 } catch(e) {
-                    console && console.warn(e.message);
+                    console.warn(e.message);
                     return;
                 }
 
@@ -159,7 +159,7 @@ OutputTester.prototype = {
                     try {
                         return fn.apply(this, arguments);
                     } catch (e) {
-                        console && console.warn(e);
+                        console.warn(e);
                     }
                 }
             });

--- a/js/output/shared/output-tester.js
+++ b/js/output/shared/output-tester.js
@@ -37,9 +37,7 @@ OutputTester.prototype = {
                 try {
                     tester.exec(validate);
                 } catch(e) {
-                    if (window.console) {
-                        console.warn(e.message);
-                    }
+                    console && console.warn(e.message);
                     return;
                 }
 
@@ -161,9 +159,7 @@ OutputTester.prototype = {
                     try {
                         return fn.apply(this, arguments);
                     } catch (e) {
-                        if (window.console) {
-                            console.warn(e);
-                        }
+                        console && console.warn(e);
                     }
                 }
             });

--- a/js/output/sql/sql-output.js
+++ b/js/output/sql/sql-output.js
@@ -111,7 +111,7 @@ window.SQLOutput = Backbone.View.extend({
             errorMessage += ". " +
                 i18n._("Are you missing a parenthesis?");
         } else if (isSyntaxError &&
-                statement.indexOf("CREATE") !== -1 && 
+                statement.indexOf("CREATE") !== -1 &&
                 statement.indexOf("TABLE") === -1 && (
                     statement.indexOf("INDEX") === -1 ||
                     statement.indexOf("TRIGGER") === -1 ||
@@ -133,7 +133,7 @@ window.SQLOutput = Backbone.View.extend({
                 i18n._("Do you have a semi-colon after each statement?");
         } else if (isSyntaxError &&
             statement.indexOf("INSERT") !== -1 &&
-            statement.search(/[^INSERT],\d*\s*[a-zA-Z]+/) > -1 
+            statement.search(/[^INSERT],\d*\s*[a-zA-Z]+/) > -1
             ) {
             errorMessage += ". " +
                 i18n._("Are you missing quotes around text values?");
@@ -312,8 +312,7 @@ window.SQLOutput = Backbone.View.extend({
                     // figure out whether we hit this case.
                     var message = i18n._("Error: %(message)s",
                         {message: errors[errors.length - 1].message});
-                    // TODO(jeresig): Find a better way to show this
-                    this.output.$el.find(".test-errors").text(message).show();
+                    console && console.warn(message);
                     this.tester.testContext.assert(false, message,
                         i18n._("A critical problem occurred in your program " +
                             "making it unable to run."));

--- a/js/output/sql/sql-output.js
+++ b/js/output/sql/sql-output.js
@@ -312,7 +312,7 @@ window.SQLOutput = Backbone.View.extend({
                     // figure out whether we hit this case.
                     var message = i18n._("Error: %(message)s",
                         {message: errors[errors.length - 1].message});
-                    console && console.warn(message);
+                    console.warn(message);
                     this.tester.testContext.assert(false, message,
                         i18n._("A critical problem occurred in your program " +
                             "making it unable to run."));

--- a/js/output/sql/sql-tester.js
+++ b/js/output/sql/sql-tester.js
@@ -246,10 +246,8 @@ SQLTester.prototype.testMethods = {
 
         for (var key in params) {
             if (params[key][0] !== "$") {
-                if (window.console) {
-                    console.warn("Invalid parameter in constraint " +
+                console && console.warn("Invalid parameter in constraint " +
                             "(should begin with a '$'): ", params[key]);
-                }
                 return null;
             }
         }
@@ -364,12 +362,12 @@ SQLTester.prototype.testMethods = {
                 }
             }
         }
-        
+
         return { success: true };
     },
 
     /**
-     * @param templateDBInfo: A template DB to match column names 
+     * @param templateDBInfo: A template DB to match column names
      * @return {success} if user table contains same column names
      *   Note - it could also contain other names,
      *   use matchTableColumnCount if you need to be exact.
@@ -617,8 +615,8 @@ SQLTester.prototype.testMethods = {
 
         // This allows us to check Step 1 results even if
         //  Step 2 results are not correct, for example.
-        numResults = numResults || results.length; 
-        
+        numResults = numResults || results.length;
+
         // Make sure we have similar results
         for (var i = 0; i < numResults; i++) {
             var res = results[i];
@@ -642,7 +640,7 @@ SQLTester.prototype.testMethods = {
     moreResultsThan(num) {
         var dbInfo = this.userCode;
         var results = dbInfo.results;
-        return { success: (results.length > num) };            
+        return { success: (results.length > num) };
     },
 
     /*

--- a/js/output/sql/sql-tester.js
+++ b/js/output/sql/sql-tester.js
@@ -246,7 +246,7 @@ SQLTester.prototype.testMethods = {
 
         for (var key in params) {
             if (params[key][0] !== "$") {
-                console && console.warn("Invalid parameter in constraint " +
+                console.warn("Invalid parameter in constraint " +
                             "(should begin with a '$'): ", params[key]);
                 return null;
             }

--- a/js/output/webpage/webpage-output.js
+++ b/js/output/webpage/webpage-output.js
@@ -114,7 +114,7 @@ window.WebpageOutput = Backbone.View.extend({
                 disableTags: ["iframe", "embed", "object", "frameset", "frame"]
             });
         } catch (e) {
-            console && console.warn(e);
+            console.warn(e);
             results.error = {
                 type: "UNKNOWN_SLOWPARSE_ERROR"
             };
@@ -263,7 +263,7 @@ window.WebpageOutput = Backbone.View.extend({
                     // figure out whether we hit this case.
                     var message = i18n._("Error: %(message)s",
                         {message: errors[errors.length - 1].message});
-                    console && console.warn(message);
+                    console.warn(message);
                     this.tester.testContext.assert(false, message,
                         i18n._("A critical problem occurred in your program " +
                             "making it unable to run."));

--- a/js/output/webpage/webpage-output.js
+++ b/js/output/webpage/webpage-output.js
@@ -114,9 +114,7 @@ window.WebpageOutput = Backbone.View.extend({
                 disableTags: ["iframe", "embed", "object", "frameset", "frame"]
             });
         } catch (e) {
-            if (window.console) {
-                console.warn(e);
-            }
+            console && console.warn(e);
             results.error = {
                 type: "UNKNOWN_SLOWPARSE_ERROR"
             };
@@ -265,8 +263,7 @@ window.WebpageOutput = Backbone.View.extend({
                     // figure out whether we hit this case.
                     var message = i18n._("Error: %(message)s",
                         {message: errors[errors.length - 1].message});
-                    // TODO(jeresig): Find a better way to show this
-                    this.output.$el.find(".test-errors").text(message).show();
+                    console && console.warn(message);
                     this.tester.testContext.assert(false, message,
                         i18n._("A critical problem occurred in your program " +
                             "making it unable to run."));

--- a/js/output/webpage/webpage-tester.js
+++ b/js/output/webpage/webpage-tester.js
@@ -123,7 +123,7 @@
 
                 for (var key in variables) {
                     if (variables[key][0] !== "$") {
-                        console.warn("Invalid variable in constraint (should begin with a '$'): ", variables[key]);
+                        console && console.warn("Invalid variable in constraint (should begin with a '$'): ", variables[key]);
                         return null;
                     }
                 }
@@ -549,9 +549,7 @@
                     message: callbacks && callbacks.failure
                 };
             } catch (e) {
-                if (window.console) {
-                    console.warn(e);
-                }
+                console && console.warn(e);
                 return {
                     success: true,
                     message: i18n._("Hm, we're having some trouble " +

--- a/js/output/webpage/webpage-tester.js
+++ b/js/output/webpage/webpage-tester.js
@@ -123,7 +123,7 @@
 
                 for (var key in variables) {
                     if (variables[key][0] !== "$") {
-                        console && console.warn("Invalid variable in constraint (should begin with a '$'): ", variables[key]);
+                        console.warn("Invalid variable in constraint (should begin with a '$'): ", variables[key]);
                         return null;
                     }
                 }
@@ -549,7 +549,7 @@
                     message: callbacks && callbacks.failure
                 };
             } catch (e) {
-                console && console.warn(e);
+                console.warn(e);
                 return {
                     success: true,
                     message: i18n._("Hm, we're having some trouble " +


### PR DESCRIPTION
### High-level description of change

The main point of this PR is to remove "window" from "window.console" statements, as this moves us towards easier webpack integration. We have some places where we use "console &&" before console, so I normalized to that everywhere. However, I'm happy to remove "console &&" if that's not needed.

### Are there performance implications for this change?

No
### Have you added tests to cover this new/updated code?

No, just ran current tests.

### Risks involved

There's some risk of console && not working in all browsers, but at this point, with modern browsers, that seems less likely.
I checked webapp and we have a few different approaches there.

### Are there any dependencies or blockers for merging this?

No

### How can we verify that this change works?

Use the PJS editor, all should work with no errors, particularly debug()

