### PR TITLE
Initialize globals object in PJSCodeInjector

### DIFF
--- a/build/js/live-editor.output_pjs.js
+++ b/build/js/live-editor.output_pjs.js
@@ -76,6 +76,7 @@ var PJSCodeInjector = (function () {
         Object.assign(this, defaultOptions, options);
         this.DUMMY = this.processing.draw; // initially draw is a DUMMY method
         this.seed = null;
+        this.globals = {};
 
         this.addMethods(this.additionalMethods);
         this.reseedRandom();

--- a/js/output/pjs/pjs-code-injector.js
+++ b/js/output/pjs/pjs-code-injector.js
@@ -35,6 +35,7 @@ class PJSCodeInjector {
         Object.assign(this, defaultOptions, options);
         this.DUMMY = this.processing.draw;  // initially draw is a DUMMY method
         this.seed = null;
+        this.globals = {};
 
         this.addMethods(this.additionalMethods);
         this.reseedRandom();


### PR DESCRIPTION
(Cue long description of 1-line fix!)

### High-level description of change

In a recent PR, I changed from using Deferreds to Promises. That change meant in difference in the way errors are thrown from PJSCodeInjector.injectCode (likely due to implementation differences between Deferreds and Promises). That in turn meant that a previously swallowed error then became an actual breaking error.

The error is this:
* this.globals in PJSCodeInjector is not initialized in the constructor, it is only assigned to the results of extractGlobals when we run the JSHint check
* if a program is completely empty upon starting, we don't run the hint check ( if (skip || !userCode)).
* Then we run injectCode, which calls hasOrHadDrawLoop, which checks globals ( if (this.globals[x]) and then errors because globals is undefined.

My fix is to initialize globals in the constructor to an empty object. (I did actually have that change in my BigPR, but I didn't remember why it was needed... now I know!)

### Have you added tests to cover this new/updated code?

No :( I tried to add a test for this, but I couldn't get my test of empty code to fail. I could possibly get it working if I spend more time.

Note that this error became blatantly obvious in webapp, since /cs/new/pjs is my standard URL to hit. It's just not obvious in demos because we have a default code.

### Risks involved

I'm nervous that there's a change in how errors are thrown. I experimented with .catch() after injectCode, but I'm wary of adding that, as our current tests that check for errors do still work. It might be that the change in error throwing is only relevant to errors in our code, in which case, it's okay for those to actually be fatal.

### How can we verify that this change works?

- Locally, delete the default value of code from the demo index file
- In webapp, go to /cs/new/pjs


