### PR TITLE
Renaming seeking property to runningSeek

### DIFF
--- a/build/js/live-editor.shared.js
+++ b/build/js/live-editor.shared.js
@@ -374,7 +374,7 @@ window.ScratchpadRecord = Backbone.Model.extend({
 
     play: function play() {
         // Don't play if we're already playing or recording
-        if (this.recording || this.playing || this.seeking || !this.commands || this.commands.length === 0) {
+        if (this.recording || this.playing || this.runningSeek || !this.commands || this.commands.length === 0) {
             return;
         }
 

--- a/build/js/live-editor.shared.js
+++ b/build/js/live-editor.shared.js
@@ -139,7 +139,7 @@ window.ScratchpadRecord = Backbone.Model.extend({
 
         // True when we actively seeking to a new position and potentially
         // building the cache.
-        this.seeking = false;
+        this.runningSeek = false;
     },
 
     setActualInitData: function setActualInitData(actualData) {
@@ -262,11 +262,11 @@ window.ScratchpadRecord = Backbone.Model.extend({
     seekTo: function seekTo(time) {
         var _this = this;
 
-        if (this.seeking) {
+        if (this.runningSeek) {
             return;
         }
 
-        this.seeking = true;
+        this.runningSeek = true;
 
         // Initialize and seek to the desired position
         this.pauseTime = new Date().getTime();
@@ -333,11 +333,10 @@ window.ScratchpadRecord = Backbone.Model.extend({
             if (currentOffset <= seekPos) {
                 window.requestAnimationFrame(buildCache);
             } else {
-                _this.seeking = false;
+                _this.runningSeek = false;
                 _this.trigger("seekDone");
             }
         };
-
         window.requestAnimationFrame(buildCache);
     },
 

--- a/js/shared/record.js
+++ b/js/shared/record.js
@@ -258,7 +258,7 @@ window.ScratchpadRecord = Backbone.Model.extend({
 
     play: function() {
         // Don't play if we're already playing or recording
-        if (this.recording || this.playing || this.seeking || !this.commands ||
+        if (this.recording || this.playing || this.runningSeek || !this.commands ||
                 this.commands.length === 0) {
             return;
         }

--- a/js/shared/record.js
+++ b/js/shared/record.js
@@ -24,7 +24,7 @@ window.ScratchpadRecord = Backbone.Model.extend({
 
         // True when we actively seeking to a new position and potentially
         // building the cache.
-        this.seeking = false;
+        this.runningSeek = false;
     },
 
     setActualInitData: function(actualData) {
@@ -145,11 +145,11 @@ window.ScratchpadRecord = Backbone.Model.extend({
     // Seek to a given position in the playback, executing all the
     // commands in the interim
     seekTo: function(time) {
-        if (this.seeking) {
+        if (this.runningSeek) {
             return;
         }
 
-        this.seeking = true;
+        this.runningSeek = true;
 
         // Initialize and seek to the desired position
         this.pauseTime = (new Date()).getTime();
@@ -216,11 +216,10 @@ window.ScratchpadRecord = Backbone.Model.extend({
             if (currentOffset <= seekPos) {
                 window.requestAnimationFrame(buildCache);
             } else {
-                this.seeking = false;
+                this.runningSeek = false;
                 this.trigger("seekDone");
             }
         }
-
         window.requestAnimationFrame(buildCache);
     },
 
@@ -363,7 +362,7 @@ window.ScratchpadRecord = Backbone.Model.extend({
             // Specifically this applies to replace (which is a remove and an insert back to back)
             if (this.synchronizedTime === undefined) {
                 this.synchronizedTime = Math.floor((new Date).getTime() - this.startTime);
-                setTimeout(function() { 
+                setTimeout(function() {
                     this.synchronizedTime = undefined;
                 }.bind(this), 0);
             }


### PR DESCRIPTION
### High-level description of change

This PR changes the .seeking property introduced in PR #665 to .runningSeek. We actually already had a .seeking property (set by files outside record.js, unfortunately), and it doesn't seem like it is meant to be semantically the same as the other .seeking property.

This change is part of a multi-part change to fix the issue where fast-forwarding causes glitchy data. The other change is in webapp, and I will send a PR for that shortly.

### Are there performance implications for this change?

No.

### Have you added tests to cover this new/updated code?

No, we don't have tests for this behavior.

### Risks involved

It could be that .seeking is meant to be the same as the .seeking set elsewhere, in which case I need to debug further. For my tests, I needed to rename it to get things working as expected.

### Are there any dependencies or blockers for merging this?

This can be merged before webapp, but we should probably deploy changes together.

### How can we verify that this change works?

Visit /computing/computer-programming/programming/coloring/pt/coloring-with-code, fast forward to near the end. See syntactic code with no errors. Specifically, don't see dangling code like `0, 0, 255`, caused by the tooltip autofiller.

