### PR TITLE
Make row/rows translatable

### DIFF
--- a/build/js/live-editor.output_sql.js
+++ b/build/js/live-editor.output_sql.js
@@ -23,7 +23,9 @@ this["Handlebars"]["templates"]["sql-results"] = Handlebars.template({"1":functi
     + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
     + "</a> <span class=\"row-count\">"
     + alias4(((helper = (helper = helpers.rowCount || (depth0 != null ? depth0.rowCount : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"rowCount","hash":{},"data":data}) : helper)))
-    + " row</span></th>\n";
+    + " "
+    + alias4(((helper = (helper = helpers.rowMsg || (depth0 != null ? depth0.rowMsg : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"rowMsg","hash":{},"data":data}) : helper)))
+    + "</span></th>\n";
 },"6":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
@@ -31,7 +33,9 @@ this["Handlebars"]["templates"]["sql-results"] = Handlebars.template({"1":functi
     + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
     + "</a> <span class=\"row-count\">"
     + alias4(((helper = (helper = helpers.rowCount || (depth0 != null ? depth0.rowCount : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"rowCount","hash":{},"data":data}) : helper)))
-    + " rows</span></th>\n";
+    + " "
+    + alias4(((helper = (helper = helpers.rowsMsg || (depth0 != null ? depth0.rowsMsg : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"rowsMsg","hash":{},"data":data}) : helper)))
+    + "</span></th>\n";
 },"8":function(container,depth0,helpers,partials,data) {
     var stack1, helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
@@ -1065,7 +1069,9 @@ window.SQLOutput = Backbone.View.extend({
             tables: tables,
             results: results,
             databaseMsg: i18n._("Database Schema"),
-            resultsMsg: i18n._("Query results")
+            resultsMsg: i18n._("Query results"),
+            rowMsg: i18n._("row"),
+            rowsMsg: i18n._("rows")
         });
 
         var doc = this.getDocument();

--- a/build/tmpl/sql-results.js
+++ b/build/tmpl/sql-results.js
@@ -23,7 +23,9 @@ this["Handlebars"]["templates"]["sql-results"] = Handlebars.template({"1":functi
     + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
     + "</a> <span class=\"row-count\">"
     + alias4(((helper = (helper = helpers.rowCount || (depth0 != null ? depth0.rowCount : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"rowCount","hash":{},"data":data}) : helper)))
-    + " row</span></th>\n";
+    + " "
+    + alias4(((helper = (helper = helpers.rowMsg || (depth0 != null ? depth0.rowMsg : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"rowMsg","hash":{},"data":data}) : helper)))
+    + "</span></th>\n";
 },"6":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
@@ -31,7 +33,9 @@ this["Handlebars"]["templates"]["sql-results"] = Handlebars.template({"1":functi
     + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
     + "</a> <span class=\"row-count\">"
     + alias4(((helper = (helper = helpers.rowCount || (depth0 != null ? depth0.rowCount : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"rowCount","hash":{},"data":data}) : helper)))
-    + " rows</span></th>\n";
+    + " "
+    + alias4(((helper = (helper = helpers.rowsMsg || (depth0 != null ? depth0.rowsMsg : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"rowsMsg","hash":{},"data":data}) : helper)))
+    + "</span></th>\n";
 },"8":function(container,depth0,helpers,partials,data) {
     var stack1, helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 

--- a/js/output/sql/sql-output.js
+++ b/js/output/sql/sql-output.js
@@ -392,6 +392,8 @@ window.SQLOutput = Backbone.View.extend({
             results: results,
             databaseMsg: i18n._("Database Schema"),
             resultsMsg: i18n._("Query results"),
+            rowMsg: i18n._("row"),
+            rowsMsg: i18n._("rows"),
         });
 
         var doc = this.getDocument();

--- a/tmpl/sql-results.handlebars
+++ b/tmpl/sql-results.handlebars
@@ -92,9 +92,9 @@ table.sql-schema-table .row-count {
         <table class="sql-schema-table" data-table-name="{{name}}">
         <thead>
         {{#if hasSingleRow}}
-            <th><a href="javascript:void(0)">{{name}}</a> <span class="row-count">{{rowCount}} row</span></th>
+            <th><a href="javascript:void(0)">{{name}}</a> <span class="row-count">{{rowCount}} {{rowMsg}}</span></th>
         {{else}}
-            <th><a href="javascript:void(0)">{{name}}</a> <span class="row-count">{{rowCount}} rows</span></th>
+            <th><a href="javascript:void(0)">{{name}}</a> <span class="row-count">{{rowCount}} {{rowsMsg}}</span></th>
         {{/if}}
         </thead>
         <tbody>


### PR DESCRIPTION
### High-level description of change

This makes it possible to translate "row"/"rows", two strings in the sql-results handlebars template.

### Are there performance implications for this change?

No

### Have you added tests to cover this new/updated code?

No, no tests are for translatability.

### Risks involved

Standard danger of short strings: It's possible rows/rows already has a translation in Crowdin that doesn't match our usage well here, so I guess we'll find that out.

### Are there any dependencies or blockers for merging this?

No

### How can we verify that this change works?

Open SQL demo locally (http://localhost:8086/demos/simple/sql.html) or /cs/new/sql in webapp

See "row" or "rows" in schema table, depending on number of INSERTs:

CREATE TABLE books (id INTEGER PRIMARY KEY,name TEXT,rating INTEGER);
insert into Books VALUES(1,"Harry Potter", 5); 
insert into Books VALUES(2,"Harry Potter", 5); 

See string show up on CrowdIn a few days after deploy.

