### PR TITLE
Remove unused gutter decorations & underline marker for errors

### DIFF
--- a/build/css/live-editor.ui.css
+++ b/build/css/live-editor.ui.css
@@ -282,7 +282,7 @@
 }
 
 .scratchpad-ace-editor .ace_problem_line {
-    border-bottom: 1px dashed orange;
+    border-bottom: 1px dotted orange;
     position: absolute;
 }
 

--- a/build/css/live-editor.ui.css
+++ b/build/css/live-editor.ui.css
@@ -271,11 +271,6 @@
     z-index: 2;
 }
 
-/* Style overrides for the ace editor */
-.scratchpad-ace-editor .ace_gutter {
-    background: #F5F3E5;
-}
-
 .scratchpad-ace-editor .ace_tooltip {
     max-width: 550px; /* Ensures tooltip isn't cut off */
     white-space: normal; /* Allows multi-lines to wrap */
@@ -288,19 +283,6 @@
 
 .scratchpad-ace-editor .ace_scroller {
     overflow-x: hidden;
-}
-
-.scratchpad-ace-editor .ace_sb {
-    overflow-y: auto;
-}
-
-.scratchpad-ace-editor .ace_active_line {
-    background: rgba(255, 207, 207, 0.9);
-    transition: background 200ms ease-in-out;
-}
-
-.scratchpad-ace-editor .ace_active_line.hilite {
-    background: rgba(255, 100, 100, 1);
 }
 
 .scratchpad-ace-editor .ace_line {

--- a/build/js/live-editor.editor_ace.js
+++ b/build/js/live-editor.editor_ace.js
@@ -1,6 +1,5 @@
 window.AceEditor = Backbone.View.extend({
     dom: {
-        ACTIVE_LINE: ".ace_active_line",
         TEXT_INPUT: "textarea",
         CONTENT: "div.ace_content"
     },
@@ -276,20 +275,7 @@ window.AceEditor = Backbone.View.extend({
 
     // Set the cursor position on the editor
     setErrorHighlight: function setErrorHighlight(shouldHighlight) {
-        var self = this;
-
         this.editor.setHighlightActiveLine(shouldHighlight);
-
-        // Delay adding a flash until the active line is shown
-        setTimeout(function () {
-            // Add the hilite flash
-            var line = self.$(self.dom.ACTIVE_LINE).addClass("hilite");
-
-            // And quickly remove it again (to give a nice flash animation)
-            setTimeout(function () {
-                line.removeClass("hilite");
-            }, 100);
-        }, 1);
     },
 
     // Allow for toggling of the editor gutter

--- a/build/js/live-editor.ui.js
+++ b/build/js/live-editor.ui.js
@@ -1160,12 +1160,6 @@ window.LiveEditor = Backbone.View.extend({
             self.record.log("restart");
         });
 
-        // Handle the gutter errors
-        $el.on("click", this.dom.GUTTER_ERROR, function () {
-            var lineNum = parseInt($(this).text(), 10);
-            self.setErrorPosition(this.gutterDecorations[lineNum]);
-        });
-
         // Handle clicks on the thinking Error Buddy
         $el.on("click", this.dom.ERROR_BUDDY_THINKING, function () {
             self.setErrorPosition(0);
@@ -1862,15 +1856,6 @@ window.LiveEditor = Backbone.View.extend({
         });
     },
 
-    removeGutterDecorations: function removeGutterDecorations() {
-        // Remove old gutter decorations
-        var session = this.editor.editor.session;
-        _.each(this.gutterDecorations, function (errorOffset, errorRow) {
-            session.removeGutterDecoration(errorRow - 1, "ace_error");
-        });
-    },
-
-    gutterDecorations: [],
     errorCursorRow: null,
     showError: null,
 
@@ -1902,32 +1887,13 @@ window.LiveEditor = Backbone.View.extend({
 
             // Remove old gutter markers and decorations
             this.removeMarkers();
-            this.removeGutterDecorations();
-
-            // Add gutter decorations
-            var gutterDecorations = [];
-            _.each(errors, function (error, index) {
-                // Create a log of which row corresponds with which error
-                // message so that when the user clicks a gutter marker they
-                // are shown the relevant error message.
-                if (gutterDecorations[error.row + 1] === null) {
-                    gutterDecorations[error.row + 1] = index;
-                    session.addGutterDecoration(error.row, "ace_error");
-                }
-
-                this.addUnderlineMarker(error.row);
-            }, this);
-
-            this.gutterDecorations = gutterDecorations;
 
             // Set the errors
             this.setErrors(errors);
 
             this.maybeShowErrors();
         } else {
-            // If there are no errors, remove the gutter decorations that marked
-            // the errors and reset our state.
-            this.removeGutterDecorations();
+            // If there are no errors, reset our state.
             this.setErrors([]);
             this.setHappyState();
             this.showError = false;

--- a/build/js/live-editor.ui.js
+++ b/build/js/live-editor.ui.js
@@ -1765,8 +1765,7 @@ window.LiveEditor = Backbone.View.extend({
         }
 
         if (this.editorType.indexOf("ace_") === 0 && data.results) {
-            // Remove previously added markers
-            this.removeMarkers();
+            this.removeUnderlineMarkers();
             if (data.results.assertions || data.results.warnings) {
                 // Add gutter warning markers in the editor.
                 // E.g. Add `Program.assertEqual(2, 4);` to the live editor to see
@@ -1847,11 +1846,10 @@ window.LiveEditor = Backbone.View.extend({
         this.editor.editor.session.addMarker(new AceRange(row, 0, row, line.length), "ace_problem_line", "text", false);
     },
 
-    removeMarkers: function removeMarkers() {
-        // Remove previously added markers and decorations
+    removeUnderlineMarkers: function removeUnderlineMarkers() {
         var session = this.editor.editor.session;
         var markers = session.getMarkers();
-        _.each(markers, function (marker, markerId) {
+        Object.keys(markers).forEach(function (markerId) {
             session.removeMarker(markerId);
         });
     },
@@ -1885,8 +1883,7 @@ window.LiveEditor = Backbone.View.extend({
             // There is an error
             var session = this.editor.editor.session;
 
-            // Remove old gutter markers and decorations
-            this.removeMarkers();
+            this.removeUnderlineMarkers();
 
             // Set the errors
             this.setErrors(errors);

--- a/css/ui/style.css
+++ b/css/ui/style.css
@@ -116,7 +116,7 @@
 }
 
 .scratchpad-ace-editor .ace_problem_line {
-    border-bottom: 1px dashed orange;
+    border-bottom: 1px dotted orange;
     position: absolute;
 }
 

--- a/css/ui/style.css
+++ b/css/ui/style.css
@@ -105,11 +105,6 @@
     z-index: 2;
 }
 
-/* Style overrides for the ace editor */
-.scratchpad-ace-editor .ace_gutter {
-    background: #F5F3E5;
-}
-
 .scratchpad-ace-editor .ace_tooltip {
     max-width: 550px; /* Ensures tooltip isn't cut off */
     white-space: normal; /* Allows multi-lines to wrap */
@@ -122,19 +117,6 @@
 
 .scratchpad-ace-editor .ace_scroller {
     overflow-x: hidden;
-}
-
-.scratchpad-ace-editor .ace_sb {
-    overflow-y: auto;
-}
-
-.scratchpad-ace-editor .ace_active_line {
-    background: rgba(255, 207, 207, 0.9);
-    transition: background 200ms ease-in-out;
-}
-
-.scratchpad-ace-editor .ace_active_line.hilite {
-    background: rgba(255, 100, 100, 1);
 }
 
 .scratchpad-ace-editor .ace_line {

--- a/js/editors/ace/editor-ace.js
+++ b/js/editors/ace/editor-ace.js
@@ -1,6 +1,5 @@
 window.AceEditor = Backbone.View.extend({
     dom: {
-        ACTIVE_LINE: ".ace_active_line",
         TEXT_INPUT: "textarea",
         CONTENT: "div.ace_content"
     },
@@ -300,20 +299,7 @@ window.AceEditor = Backbone.View.extend({
 
     // Set the cursor position on the editor
     setErrorHighlight: function(shouldHighlight) {
-        var self = this;
-
         this.editor.setHighlightActiveLine(shouldHighlight);
-
-        // Delay adding a flash until the active line is shown
-        setTimeout(function() {
-            // Add the hilite flash
-            var line = self.$(self.dom.ACTIVE_LINE).addClass("hilite");
-
-            // And quickly remove it again (to give a nice flash animation)
-            setTimeout(function() {
-                line.removeClass("hilite");
-            }, 100);
-        }, 1);
     },
 
     // Allow for toggling of the editor gutter

--- a/js/live-editor.js
+++ b/js/live-editor.js
@@ -439,12 +439,6 @@ window.LiveEditor = Backbone.View.extend({
             self.record.log("restart");
         });
 
-        // Handle the gutter errors
-        $el.on("click", this.dom.GUTTER_ERROR, function() {
-            var lineNum = parseInt($(this).text(), 10);
-            self.setErrorPosition(this.gutterDecorations[lineNum]);
-        });
-
         // Handle clicks on the thinking Error Buddy
         $el.on("click", this.dom.ERROR_BUDDY_THINKING, function() {
             self.setErrorPosition(0);
@@ -1164,15 +1158,6 @@ window.LiveEditor = Backbone.View.extend({
         });
     },
 
-    removeGutterDecorations: function() {
-        // Remove old gutter decorations
-        var session = this.editor.editor.session;
-        _.each(this.gutterDecorations, function(errorOffset, errorRow) {
-            session.removeGutterDecoration(errorRow - 1, "ace_error");
-        });
-    },
-
-    gutterDecorations: [],
     errorCursorRow: null,
     showError: null,
 
@@ -1204,23 +1189,6 @@ window.LiveEditor = Backbone.View.extend({
 
             // Remove old gutter markers and decorations
             this.removeMarkers();
-            this.removeGutterDecorations();
-
-            // Add gutter decorations
-            var gutterDecorations = [];
-            _.each(errors, function(error, index) {
-                // Create a log of which row corresponds with which error
-                // message so that when the user clicks a gutter marker they
-                // are shown the relevant error message.
-                if (gutterDecorations[error.row + 1] === null) {
-                    gutterDecorations[error.row + 1] = index;
-                    session.addGutterDecoration(error.row, "ace_error");
-                }
-
-                this.addUnderlineMarker(error.row);
-            }, this);
-
-            this.gutterDecorations = gutterDecorations;
 
             // Set the errors
             this.setErrors(errors);
@@ -1228,9 +1196,7 @@ window.LiveEditor = Backbone.View.extend({
             this.maybeShowErrors();
 
         } else {
-            // If there are no errors, remove the gutter decorations that marked
-            // the errors and reset our state.
-            this.removeGutterDecorations();
+            // If there are no errors, reset our state.
             this.setErrors([]);
             this.setHappyState();
             this.showError = false;

--- a/js/live-editor.js
+++ b/js/live-editor.js
@@ -1067,8 +1067,7 @@ window.LiveEditor = Backbone.View.extend({
         }
 
         if (this.editorType.indexOf("ace_") === 0 && data.results) {
-            // Remove previously added markers
-            this.removeMarkers();
+            this.removeUnderlineMarkers();
             if (data.results.assertions || data.results.warnings) {
                 // Add gutter warning markers in the editor.
                 // E.g. Add `Program.assertEqual(2, 4);` to the live editor to see
@@ -1149,11 +1148,10 @@ window.LiveEditor = Backbone.View.extend({
            "ace_problem_line", "text", false);
     },
 
-    removeMarkers: function() {
-        // Remove previously added markers and decorations
+    removeUnderlineMarkers: function() {
         var session = this.editor.editor.session;
         var markers = session.getMarkers();
-        _.each(markers, function(marker, markerId) {
+        Object.keys(markers).forEach((markerId) => {
             session.removeMarker(markerId);
         });
     },
@@ -1187,8 +1185,7 @@ window.LiveEditor = Backbone.View.extend({
             // There is an error
             var session = this.editor.editor.session;
 
-            // Remove old gutter markers and decorations
-            this.removeMarkers();
+            this.removeUnderlineMarkers();
 
             // Set the errors
             this.setErrors(errors);


### PR DESCRIPTION
### High-level description of change

We currently immediately render a dashed orange line under an error-ful line as you're typing. This was functionality that was broken that I fixed a few months ago. 

https://khanacademy.slack.com/files/UB9GHCAJF/FDJH16ZV4/screen_shot_2018-10-18_at_7.58.23_am.png

I'm finding the orange line to be very distracting, since it happens immediately and constantly. That isn't in line with our philosophy of giving the user time before we annoy them about errors 
(See: OhNoesOhYes project and this blog post on feedback in online education: https://blog.mrmeyer.com/2016/the-future-of-handwriting-recognition-adaptive-feedback-in-math-education/)

This PR removes the orange line for immediate JS errors. It keeps the orange line for CSS warnings and for Program.assertEqual() failures. It'd be nice for those to be delayed, but they're much rarer and more often signal versus noise.

This PR also removes the code that added gutter decorations for errors, as the code hasn't actually been running for a few years. For a brief period of time, the gutter decoration code would display red error icons, wherever the orange line was displayed. The gutter decorations were buggy (they sometimes displayed for dozens of lines, depending on the error) and the red was jarring.  It appears that we removed them either intentionally or accidentally, and I think that ended up being A Good Thing.  So this PR deletes that not-working-anyway code.

This PR also changes the orange line (for CSS warnings and assertEqual failures) to be a dotted line instead of dashed. The dashed line jiggles too much while you're typing, as it recalculates the dash width. The dotted line doesn't jiggle, as the dots are constant-sized.

### Are there performance implications for this change?

Less code, so teeensy tiny bit faster.

### Have you added tests to cover this new/updated code?

There are no tests around this UI.

### Risks involved

Hm. I think one potential beneficial side effect of the orange underline is that it shows up in talk-throughs, so it's clear when the current code has an error. It will be less clear now, since we don't show OhNoes while a talk-through is running. However, given that the orange underline wasn't displaying for a while, it seems fine that it's going to go away again.
(It could be nice to show mini-OhNoes during a talk-through).

### Are there any dependencies or blockers for merging this?

No

### How can we verify that this change works?

Go to /cs/new/pjs, type code, don't see orange underline as you type. See thinking Oh Noes if you type an error, click on him to pop up big Oh Noes.
<img width="1146" alt="screen shot 2018-10-29 at 7 18 16 pm" src="https://user-images.githubusercontent.com/297042/47692434-d93b3d80-dbb2-11e8-9231-f045bcb003c9.png">

Go to /cs/new/webpage, add a CSS rule for a property like "text-crop", see orange line and warning icon.
<img width="598" alt="screen shot 2018-10-29 at 7 21 56 pm" src="https://user-images.githubusercontent.com/297042/47692423-d04a6c00-dbb2-11e8-8d7f-bf630fba1ab0.png">

Go to /cs/new/pjs, type Program.assertEqual(2, 4);, see orange line and warning icon.
<img width="453" alt="screen shot 2018-10-29 at 7 20 46 pm" src="https://user-images.githubusercontent.com/297042/47692428-d2142f80-dbb2-11e8-9a2b-95d493c373d1.png">