### PR TITLE
Remove green highlight for buttons

### DIFF
--- a/build/css/live-editor.ui.css
+++ b/build/css/live-editor.ui.css
@@ -420,12 +420,3 @@
     opacity: 0;
     z-index: 880;
 }
-
-button {
-    transition: box-shadow 200ms ease-in-out;
-    box-shadow: 0 0 0px green;
-}
-
-button.hilite {
-    box-shadow: 0 0 20px green;
-}

--- a/css/ui/style.css
+++ b/css/ui/style.css
@@ -254,12 +254,3 @@
     opacity: 0;
     z-index: 880;
 }
-
-button {
-    transition: box-shadow 200ms ease-in-out;
-    box-shadow: 0 0 0px green;
-}
-
-button.hilite {
-    box-shadow: 0 0 20px green;
-}


### PR DESCRIPTION
### High-level description of change

This PR removes a CSS rule that adds a green shadow to buttons and sets a CSS transition on them. This is a very general rule and ends up adding a transition to WonderBlocks buttons.
We should be able to safely remove it, both because most buttons are now in webapp *and* it is only a bonus effect of an extra box-shadow.

### Risks involved

It could possibly be useful somewhere for legibility. We'll find out, won't be end of the world.

### Are there any dependencies or blockers for merging this?

I'd like to update my webapp branch to point at master, once this is merged. It should be OK in any order though, given it's minor-ness.

### How can we verify that this change works?

In my webapp branch, I should see that the "Spin-off" and "Onwards" buttons have the same animation when hovering over them. They don't right now, because Spin-off is a `<button>` and Onwards is an `<a>`.
