### PR TITLE
Use Sinon's sandbox for tests

### DIFF
--- a/tests/tooltips/colorPicker_test.js
+++ b/tests/tooltips/colorPicker_test.js
@@ -1,55 +1,78 @@
 describe("colorPicker - detection", function() {
-    var mockedColorPicker = getMockedTooltip(tooltipClasses.colorPicker, ["detector", "initialize"]);
+
+    let sandbox;
+    let mockedColorPicker;
+
+    before(function () {
+        sandbox = sinon.sandbox.create();
+        mockedColorPicker = getMockedTooltip(sandbox, tooltipClasses.colorPicker, ["detector", "initialize"])
+    });
+
+    after(function () {
+        sandbox.restore();
+        mockedColorPicker.remove();
+    });
 
     it("! Before open Paren", function() {
         var line = "fill(255, 244, 0, 21);";
         var pre = "fill";
-        expect(testMockedTooltipDetection(mockedColorPicker, line, pre)).to.be(false);
+        expect(testMockedTooltipDetection(sandbox, mockedColorPicker, line, pre)).to.be(false);
     });
 
     it("After open Paren", function() {
         var line = "fill(255, 244, 0, 21);";
         var pre = "fill(";
-        expect(testMockedTooltipDetection(mockedColorPicker, line, pre)).to.be(true);
+        expect(testMockedTooltipDetection(sandbox, mockedColorPicker, line, pre)).to.be(true);
     });
 
     it("Middle", function() {
         var line = "fill(255, 244, 0, 21);";
         var pre = "fill(255, ";
-        expect(testMockedTooltipDetection(mockedColorPicker, line, pre)).to.be(true);
+        expect(testMockedTooltipDetection(sandbox, mockedColorPicker, line, pre)).to.be(true);
     });
 
     it("Before close paren", function() {
         var line = "fill(255, 244, 0, 21);";
         var pre = "fill(255, 244, 0, 21";
-        expect(testMockedTooltipDetection(mockedColorPicker, line, pre)).to.be(true);
+        expect(testMockedTooltipDetection(sandbox, mockedColorPicker, line, pre)).to.be(true);
     });
 
     it("! After close paren", function() {
         var line = "fill(255, 244, 0, 21);";
         var pre = "fill(255, 244, 0, 21)";
-        expect(testMockedTooltipDetection(mockedColorPicker, line, pre)).to.be(false);
+        expect(testMockedTooltipDetection(sandbox, mockedColorPicker, line, pre)).to.be(false);
     });
 
     it("All function names", function() {
-        _.each(["fill", "background", "stroke", "color"], function(fn) {
+        ["fill", "background", "stroke", "color"].forEach(function(fn) {
             var line = fn + "();";
             var pre = fn + "(";
-            expect(testMockedTooltipDetection(mockedColorPicker, line, pre)).to.be(true);
+            expect(testMockedTooltipDetection(sandbox, mockedColorPicker, line, pre)).to.be(true);
         });
     });
 
     it("! Different function name", function() {
         var line = "rect(255, 244, 0, 21);";
         var pre = "rect(255, ";
-        expect(testMockedTooltipDetection(mockedColorPicker, line, pre)).to.be(false);
+        expect(testMockedTooltipDetection(sandbox, mockedColorPicker, line, pre)).to.be(false);
     });
 });
 
 
 
 describe("colorPicker - selection (what it replaces)", function() {
-    var mockedColorPicker = getMockedTooltip(tooltipClasses.colorPicker, ["detector", "updateText", "initialize"]);
+    let sandbox;
+    let colorPicker;
+
+    before(function () {
+        sandbox = sinon.sandbox.create();
+        colorPicker = getTooltip(tooltipClasses.colorPicker);
+    });
+
+    after(function () {
+        sandbox.restore();
+        colorPicker.remove();
+    });
 
     it("Basic", function() {
         var line = "fill(255, 0, 0);";
@@ -60,7 +83,7 @@ describe("colorPicker - selection (what it replaces)", function() {
             b: 60
         }];
         var result = "fill(40, 50, 60);";
-        testReplace(mockedColorPicker, line, pre, updates, result);
+        testReplace(sandbox, colorPicker, line, pre, updates, result);
     });
 
     it("Many replaces", function() {
@@ -80,7 +103,7 @@ describe("colorPicker - selection (what it replaces)", function() {
             b: 253
         }];
         var result = "fill(255, 254, 253);";
-        testReplace(mockedColorPicker, line, pre, updates, result);
+        testReplace(sandbox, colorPicker, line, pre, updates, result);
     });
 
     it("Alpha", function() {
@@ -92,7 +115,7 @@ describe("colorPicker - selection (what it replaces)", function() {
             b: 60
         }];
         var result = "fill(40, 50, 60, 100);";
-        testReplace(mockedColorPicker, line, pre, updates, result);
+        testReplace(sandbox, colorPicker, line, pre, updates, result);
     });
 
     it("Not preserving garbage", function() {
@@ -104,7 +127,7 @@ describe("colorPicker - selection (what it replaces)", function() {
             b: 60
         }];
         var result = "fill(40, 50, 60);";
-        testReplace(mockedColorPicker, line, pre, updates, result);
+        testReplace(sandbox, colorPicker, line, pre, updates, result);
     });
 });
 

--- a/tests/tooltips/imageModal_test.js
+++ b/tests/tooltips/imageModal_test.js
@@ -1,76 +1,99 @@
 describe("imageModal - detection", function() {
-    var mockedImageModal = getMockedTooltip(tooltipClasses.imageModal, ["detector"]);
+
+    let sandbox;
+    let mockedImageModal;
+
+    before(function () {
+        sandbox = sinon.sandbox.create();
+        mockedImageModal = getMockedTooltip(sandbox, tooltipClasses.imageModal, ["detector"])
+    });
+
+    after(function () {
+        sandbox.restore();
+        mockedImageModal.remove();
+    });
 
     it("! Before open quote", function() {
         var line = '<img src="hello world.png" />';
         var pre = '<img src=';
-        expect(testMockedTooltipDetection(mockedImageModal, line, pre)).to.be(false);
+        expect(testMockedTooltipDetection(sandbox, mockedImageModal, line, pre)).to.be(false);
     });
 
     it("After open quote", function() {
         var line = '<img src="hello world.png" />';
         var pre = '<img src="';
-        expect(testMockedTooltipDetection(mockedImageModal, line, pre)).to.be(true);
+        expect(testMockedTooltipDetection(sandbox, mockedImageModal, line, pre)).to.be(true);
 
         var line = '<img src=\'hello world.png\' />';
         var pre = '<img src=\'';
-        expect(testMockedTooltipDetection(mockedImageModal, line, pre)).to.be(true);
+        expect(testMockedTooltipDetection(sandbox, mockedImageModal, line, pre)).to.be(true);
     });
 
     it("Middle", function() {
         var line = '<img src="hello world.png" />';
         var pre = '<img src="hello ';
-        expect(testMockedTooltipDetection(mockedImageModal, line, pre)).to.be(true);
+        expect(testMockedTooltipDetection(sandbox, mockedImageModal, line, pre)).to.be(true);
     });
 
     it("Before close quote", function() {
         var line = '<img src="hello world.png" />';
         var pre = '<img src="hello world.png';
-        expect(testMockedTooltipDetection(mockedImageModal, line, pre)).to.be(true);
+        expect(testMockedTooltipDetection(sandbox, mockedImageModal, line, pre)).to.be(true);
     });
 
     it("Spaces around equal sign", function() {
         var line = '<img src = "hello world.png" />';
         var pre = '<img src = "hello ';
-        expect(testMockedTooltipDetection(mockedImageModal, line, pre)).to.be(true);
+        expect(testMockedTooltipDetection(sandbox, mockedImageModal, line, pre)).to.be(true);
     });
 
     it("! After close quote", function() {
         var line = '<img src="hello world.png" />';
         var pre = '<img src="hello world.png"';
-        expect(testMockedTooltipDetection(mockedImageModal, line, pre)).to.be(false);
+        expect(testMockedTooltipDetection(sandbox, mockedImageModal, line, pre)).to.be(false);
     });
 
     it("With intermediate attributes", function() {
         var line = '<img style="yellow" src="hello world.png" />';
         var pre = '<img style="yellow" src="hello world.';
-        expect(testMockedTooltipDetection(mockedImageModal, line, pre)).to.be(true);
+        expect(testMockedTooltipDetection(sandbox, mockedImageModal, line, pre)).to.be(true);
     });
 
     it("! Another tag", function() {
         var line = '<a src="hello world.png" />';
         var pre = '<a src="hello';
-        expect(testMockedTooltipDetection(mockedImageModal, line, pre)).to.be(false);
+        expect(testMockedTooltipDetection(sandbox, mockedImageModal, line, pre)).to.be(false);
     });
 
     it("! Another attribute", function() {
         var line = '<img href="hello world.png" />';
         var pre = '<img href="hello';
-        expect(testMockedTooltipDetection(mockedImageModal, line, pre)).to.be(false);
+        expect(testMockedTooltipDetection(sandbox, mockedImageModal, line, pre)).to.be(false);
     });
 });
 
 
 
 describe("ImageModal - selection (what it replaces)", function() {
-    var mockedImageModal = getMockedTooltip(tooltipClasses.imageModal, ["detector", "updateText", "initialize"]);
+    let sandbox;
+    let imageModal;
+
+    before(function () {
+        sandbox = sinon.sandbox.create();
+        imageModal = getTooltip(tooltipClasses.imageModal);
+    });
+
+    after(function () {
+        sandbox.restore();
+        imageModal.remove();
+    });
 
     it("Basic", function() {
         var line = '<img src="hello world.png" />';
         var pre = '<img src="hello';
         var updates = ['goodbye-world.png'];
         var result = '<img src="goodbye-world.png" />';
-        testReplace(mockedImageModal, line, pre, updates, result);
+        testReplace(sandbox, imageModal, line, pre, updates, result);
     });
 
     it("Many replaces", function() {
@@ -78,6 +101,6 @@ describe("ImageModal - selection (what it replaces)", function() {
         var pre = '<img src="hello';
         var updates = ['goodbye-world.png', "", "kill everyone", "smiley.jpg"];
         var result = '<img src="smiley.jpg" />';
-        testReplace(mockedImageModal, line, pre, updates, result);
+        testReplace(sandbox, imageModal, line, pre, updates, result);
     });
 });

--- a/tests/tooltips/imagePicker_test.js
+++ b/tests/tooltips/imagePicker_test.js
@@ -1,61 +1,83 @@
-
 describe("imagePicker - detection", function() {
-    var mockedImagePicker = getMockedTooltip(tooltipClasses.imagePicker, ["detector"]);
+
+    let sandbox;
+    let mockedImagePicker;
+
+    before(function () {
+        sandbox = sinon.sandbox.create();
+        mockedImagePicker = getMockedTooltip(sandbox, tooltipClasses.imagePicker, ["detector"])
+    });
+
+    after(function () {
+        sandbox.restore();
+        mockedImagePicker.remove();
+    });
 
     it("Doesn't match cursor before open paren", function() {
         var line = 'getImage("cute/Blank");';
         var pre = 'getImage';
-        expect(testMockedTooltipDetection(mockedImagePicker, line, pre)).to.be(false);
+        expect(testMockedTooltipDetection(sandbox, mockedImagePicker, line, pre)).to.be(false);
     });
 
     it("Does match cursor after open paren", function() {
         var line = 'getImage("cute/Blank");';
         var pre = 'getImage(';
-        expect(testMockedTooltipDetection(mockedImagePicker, line, pre)).to.be(true);
+        expect(testMockedTooltipDetection(sandbox, mockedImagePicker, line, pre)).to.be(true);
     });
 
     it("Does match cursor in middle of filename", function() {
         var line = 'getImage("cute/Blank");';
         var pre = 'getImage("cute';
-        expect(testMockedTooltipDetection(mockedImagePicker, line, pre)).to.be(true);
+        expect(testMockedTooltipDetection(sandbox, mockedImagePicker, line, pre)).to.be(true);
     });
 
     it("Does match cursor before close paren", function() {
         var line = 'getImage("cute/Blank");';
         var pre = 'getImage("cute/Blank"';
-        expect(testMockedTooltipDetection(mockedImagePicker, line, pre)).to.be(true);
+        expect(testMockedTooltipDetection(sandbox, mockedImagePicker, line, pre)).to.be(true);
     });
 
     it("Doesn't match cursor after close paren", function() {
         var line = 'getImage("cute/Blank");';
         var pre = 'getImage("cute/Blank")';
-        expect(testMockedTooltipDetection(mockedImagePicker, line, pre)).to.be(false);
+        expect(testMockedTooltipDetection(sandbox, mockedImagePicker, line, pre)).to.be(false);
     });
 
     it("Doesn't match cursor in random code", function() {
         var line = 'randomGibberish';
         var pre = 'rand';
-        expect(testMockedTooltipDetection(mockedImagePicker, line, pre)).to.be(false);
+        expect(testMockedTooltipDetection(sandbox, mockedImagePicker, line, pre)).to.be(false);
     });
 
     it("Doesn't match cursor in different function name", function() {
         var line = 'color("hi");';
         var pre = 'color("hi"';
-        expect(testMockedTooltipDetection(mockedImagePicker, line, pre)).to.be(false);
+        expect(testMockedTooltipDetection(sandbox, mockedImagePicker, line, pre)).to.be(false);
     });
 });
 
 
 
 describe("imagePicker - selection (what it replaces)", function() {
-    var mockedImagePicker = getMockedTooltip(tooltipClasses.imagePicker, ["detector", "updateText", "initialize"]);
+    let sandbox;
+    let imagePicker;
+
+    before(function () {
+        sandbox = sinon.sandbox.create();
+        imagePicker = getTooltip(tooltipClasses.imagePicker);
+    });
+
+    after(function () {
+        sandbox.restore();
+        imagePicker.remove();
+    });
 
     it("Basic", function() {
         var line = 'getImage("blank/None");';
         var pre = 'getImage("b';
         var updates = ['avatars-blueleaf'];
         var result = 'getImage("avatars-blueleaf");';
-        testReplace(mockedImagePicker, line, pre, updates, result);
+        testReplace(sandbox, imagePicker, line, pre, updates, result);
     });
 
     it("Many replaces", function() {
@@ -63,7 +85,7 @@ describe("imagePicker - selection (what it replaces)", function() {
         var pre = 'getImage("b';
         var updates = ['bob', 'teddy', 'johnathan'];
         var result = 'getImage("johnathan");';
-        testReplace(mockedImagePicker, line, pre, updates, result);
+        testReplace(sandbox, imagePicker, line, pre, updates, result);
     });
 
     it("Garbled initial state", function() {
@@ -71,7 +93,7 @@ describe("imagePicker - selection (what it replaces)", function() {
         var pre = 'getImage(';
         var updates = ['pearl'];
         var result = 'getImage("pearl"';
-        testReplace(mockedImagePicker, line, pre, updates, result);
+        testReplace(sandbox, imagePicker, line, pre, updates, result);
     });
 });
 
@@ -93,4 +115,3 @@ describe("imagePicker - Integration tests (running on a real editor)", function(
         expect(TTE.currentTooltip).to.be.equal(TTE.tooltips.imagePicker);
     });
 });
-

--- a/tests/tooltips/index.html
+++ b/tests/tooltips/index.html
@@ -11,18 +11,6 @@
         <div id="mocha"></div>
         <script src="../../build/js/live-editor.core_deps.js"></script>
         <script>
-        // Works around this issue in PhantomJS:
-        // https://github.com/ariya/phantomjs/pull/12307
-        // Remove once PhantomJS pushes out a new release that fixes this!
-        (function() {
-            var oldSplice = Array.prototype.splice;
-            Array.prototype.splice = function(num) {
-                if (arguments.length === 1) {
-                    return Array.prototype.slice.call(this, num);
-                }
-                return oldSplice.apply(this, arguments);
-            };
-        })();
         window.LiveEditor = {registerEditor: function(){}}; //So that editor_ace.js doesn't throw an error
         </script>
         <script src="../../build/external/underscore/underscore.js"></script>

--- a/tests/tooltips/numberScrubber_test.js
+++ b/tests/tooltips/numberScrubber_test.js
@@ -1,67 +1,91 @@
 describe("numberScrubber - detection", function() {
-    var mockedNumberScrubber = getMockedTooltip(tooltipClasses.numberScrubber, ["detector", "initialize"]);
+
+    let sandbox;
+    let mockedNumberScrubber;
+
+    before(function () {
+        sandbox = sinon.sandbox.create();
+        mockedNumberScrubber = getMockedTooltip(sandbox, tooltipClasses.numberScrubber, ["detector", "initialize"])
+    });
+
+    after(function () {
+        sandbox.restore();
+        mockedNumberScrubber.remove();
+    });
 
     //numberScrubber
     it("! Before number", function() {
         var line = "Falaffel -123 Falaffel";
         var pre = "Falaffel";
-        expect(testMockedTooltipDetection(mockedNumberScrubber, line, pre)).to.be(false);
+        expect(testMockedTooltipDetection(sandbox, mockedNumberScrubber, line, pre)).to.be(false);
     });
 
     it("Start of number", function() {
         var line = "Falaffel 123 Falaffel";
         var pre = "Falaffel ";
-        expect(testMockedTooltipDetection(mockedNumberScrubber, line, pre)).to.be(true);
+        expect(testMockedTooltipDetection(sandbox, mockedNumberScrubber, line, pre)).to.be(true);
     });
 
     it("Middle of number", function() {
         var line = "Falaffel 123 Falaffel";
         var pre = "Falaffel 12";
-        expect(testMockedTooltipDetection(mockedNumberScrubber, line, pre)).to.be(true);
+        expect(testMockedTooltipDetection(sandbox, mockedNumberScrubber, line, pre)).to.be(true);
     });
 
     it("End of number", function() {
         var line = "Falaffel 123 Falaffel";
         var pre = "Falaffel 123";
-        expect(testMockedTooltipDetection(mockedNumberScrubber, line, pre)).to.be(true);
+        expect(testMockedTooltipDetection(sandbox, mockedNumberScrubber, line, pre)).to.be(true);
     });
 
     it("Start of negative", function() {
         var line = "Falaffel -123 Falaffel";
         var pre = "Falaffel ";
-        expect(testMockedTooltipDetection(mockedNumberScrubber, line, pre)).to.be(true);
+        expect(testMockedTooltipDetection(sandbox, mockedNumberScrubber, line, pre)).to.be(true);
     });
 
     it("Middle of negative", function() {
         var line = "Falaffel -123 Falaffel";
         var pre = "Falaffel -1";
-        expect(testMockedTooltipDetection(mockedNumberScrubber, line, pre)).to.be(true);
+        expect(testMockedTooltipDetection(sandbox, mockedNumberScrubber, line, pre)).to.be(true);
     });
 
     it("! After number", function() {
         var line = "Falaffel 123 Falaffel";
         var pre = "Falaffel 123 ";
-        expect(testMockedTooltipDetection(mockedNumberScrubber, line, pre)).to.be(false);
+        expect(testMockedTooltipDetection(sandbox, mockedNumberScrubber, line, pre)).to.be(false);
     });
 
     it("! Random", function() {
         var line = "Alex Rodrigues";
         var pre = "Alex Rod";
-        expect(testMockedTooltipDetection(mockedNumberScrubber, line, pre)).to.be(false);
+        expect(testMockedTooltipDetection(sandbox, mockedNumberScrubber, line, pre)).to.be(false);
     });
 });
 
 
 
 describe("numberScrubber - selection (what it replaces)", function() {
-    var mockedNumberScrubber = getMockedTooltip(tooltipClasses.numberScrubber, ["detector", "initialize", "updateText"]);
+
+    let sandbox;
+    let numberScrubber;
+
+    beforeEach(function () {
+        sandbox = sinon.sandbox.create();
+        numberScrubber = getTooltip(tooltipClasses.numberScrubber);
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+        numberScrubber.remove();
+    });
 
     it("Number", function() {
         var line = "123 1234 -fergus";
         var pre = "123 12";
         var updates = [595];
         var result = "123 595 -fergus";
-        testReplace(mockedNumberScrubber, line, pre, updates, result);
+        testReplace(sandbox, numberScrubber, line, pre, updates, result);
     });
 
     it("Negative number", function() {
@@ -69,7 +93,7 @@ describe("numberScrubber - selection (what it replaces)", function() {
         var pre = "bob(-124";
         var updates = [5956];
         var result = "bob(5956)";
-        testReplace(mockedNumberScrubber, line, pre, updates, result);
+        testReplace(sandbox, numberScrubber, line, pre, updates, result);
     });
 
     it("Subtraction", function() {
@@ -77,7 +101,7 @@ describe("numberScrubber - selection (what it replaces)", function() {
         var pre = "bob(12-124";
         var updates = [33];
         var result = "bob(12-33)";
-        testReplace(mockedNumberScrubber, line, pre, updates, result);
+        testReplace(sandbox, numberScrubber, line, pre, updates, result);
     });
 
     it("Many replaces", function() {
@@ -85,6 +109,6 @@ describe("numberScrubber - selection (what it replaces)", function() {
         var pre = "123 12";
         var updates = [595, 3434434, 121212];
         var result = "123 121212 -fergus";
-        testReplace(mockedNumberScrubber, line, pre, updates, result);
+        testReplace(sandbox, numberScrubber, line, pre, updates, result);
     });
 });

--- a/tests/tooltips/shared.js
+++ b/tests/tooltips/shared.js
@@ -1,6 +1,6 @@
-var mockObject = function(obj, mocks) {
+var mockObject = function(sandbox, obj, mocks) {
     _.each(mocks, function(method) {
-        obj[method] = sinon.spy();
+        obj[method] = sandbox.spy();
     });
     return obj;
 };
@@ -55,7 +55,7 @@ var TTEoptions = {
     }
 };
 
-var getMockedTooltip = function(Tooltip, whiteList, blackList) {
+var getMockedTooltip = function(sandbox, Tooltip, whiteList, blackList) {
     if (whiteList) {
         blackList = [];
         for (method in Tooltip.prototype) {
@@ -65,17 +65,22 @@ var getMockedTooltip = function(Tooltip, whiteList, blackList) {
         }
     }
     var oldPrototype = Tooltip.prototype;
-    Tooltip.prototype = mockObject(_.clone(Tooltip.prototype), blackList);
+    Tooltip.prototype = mockObject(sandbox, _.clone(Tooltip.prototype), blackList);
     Tooltip.prototype.render = function () {
         this.modal = {
-            show: sinon.spy(),
-            selectImg: sinon.spy()
+            show: sandbox.spy(),
+            selectImg: sandbox.spy()
         };
     };
     var tooltip = new Tooltip(TTEoptions);
     Tooltip.prototype = oldPrototype;
     return tooltip;
 };
+
+function getTooltip(Tooltip) {
+    var tooltip = new Tooltip(TTEoptions);
+    return tooltip;
+}
 
 var getTooltipRequestEvent = function(line, pre) {
     expect(line.slice(0, pre.length)).to.be.equal(pre);
@@ -102,18 +107,18 @@ var getTooltipRequestEvent = function(line, pre) {
 };
 
 
-var testMockedTooltipDetection = function(tooltip, line, pre) {
+var testMockedTooltipDetection = function(sandbox, tooltip, line, pre) {
     var event = getTooltipRequestEvent(line, pre);
     tooltip.placeOnScreen = sinon.spy();
     tooltip.detector(event);
     return !!tooltip.placeOnScreen.called;
 };
 
-function testReplace(tooltip, line, pre, updates, result) {
+function testReplace(sandbox, tooltip, line, pre, updates, result) {
     var event = getTooltipRequestEvent(line, pre);
     var newLine = line;
     var oldReplace = editor.session.replace;
-    editor.session.replace = sinon.spy(function(range, newText) {
+    editor.session.replace = sandbox.spy(function(range, newText) {
         newLine = applyReplace(newLine, range, newText);
     });
 

--- a/tests/tooltips/soundModal_test.js
+++ b/tests/tooltips/soundModal_test.js
@@ -1,47 +1,58 @@
 describe("soundModal - detection", function() {
-    var mockedSoundModal = getMockedTooltip(tooltipClasses.soundModal, ["detector"]);
+    let sandbox;
+    let mockedSoundModal;
+
+    before(function () {
+        sandbox = sinon.sandbox.create();
+        mockedSoundModal = getMockedTooltip(sandbox, tooltipClasses.soundModal, ["detector"])
+    });
+
+    after(function () {
+        sandbox.restore();
+        mockedSoundModal.remove();
+    });
 
     // These tests are basically the same as the tests in imagePicker_test.js
     it("Doesn't match cursor before open paren", function() {
         var line = 'getSound("rpg/giant-no");';
         var pre = 'getSound';
-        expect(testMockedTooltipDetection(mockedSoundModal, line, pre)).to.be(false);
+        expect(testMockedTooltipDetection(sandbox, mockedSoundModal, line, pre)).to.be(false);
     });
 
     it("Does match cursor after open paren", function() {
         var line = 'getSound("rpg/giant-no");';
         var pre = 'getSound(';
-        expect(testMockedTooltipDetection(mockedSoundModal, line, pre)).to.be(true);
+        expect(testMockedTooltipDetection(sandbox, mockedSoundModal, line, pre)).to.be(true);
     });
 
     it("Does match cursor in middle of filename", function() {
         var line = 'getSound("rpg/giant-no");';
         var pre = 'getSound("rpg';
-        expect(testMockedTooltipDetection(mockedSoundModal, line, pre)).to.be(true);
+        expect(testMockedTooltipDetection(sandbox, mockedSoundModal, line, pre)).to.be(true);
     });
 
     it("Does match cursor before close paren", function() {
         var line = 'getSound("rpg/giant-no");';
         var pre = 'getSound("rpg/giant-no"';
-        expect(testMockedTooltipDetection(mockedSoundModal, line, pre)).to.be(true);
+        expect(testMockedTooltipDetection(sandbox, mockedSoundModal, line, pre)).to.be(true);
     });
 
     it("Doesn't match cursor after close paren", function() {
         var line = 'getSound("rpg/giant-no");';
         var pre = 'getSound("rpg/giant-no")';
-        expect(testMockedTooltipDetection(mockedSoundModal, line, pre)).to.be(false);
+        expect(testMockedTooltipDetection(sandbox, mockedSoundModal, line, pre)).to.be(false);
     });
 
     it("Doesn't match cursor in random code", function() {
         var line = 'randomGibberish';
         var pre = 'rand';
-        expect(testMockedTooltipDetection(mockedSoundModal, line, pre)).to.be(false);
+        expect(testMockedTooltipDetection(sandbox, mockedSoundModal, line, pre)).to.be(false);
     });
 
     it("Doesn't match cursor in different function name", function() {
         var line = 'color("hi");';
         var pre = 'color("hi"';
-        expect(testMockedTooltipDetection(mockedSoundModal, line, pre)).to.be(false);
+        expect(testMockedTooltipDetection(sandbox, mockedSoundModal, line, pre)).to.be(false);
     });
 });
 


### PR DESCRIPTION
### High-level description of change

This change was extracted from https://github.com/Khan/live-editor/pull/688

This PR changes the tooltip tests to use Sinon's sandbox:
https://sinonjs.org/releases/latest/sandbox/
The sandbox makes it easy to clean up fakes (stub(), spy()), which are used throughout the tooltips tests. The tests are less fragile when we clean up fakes after we're done with them.

### Risks involved

Tests pass, seems safe. I've used sandbox in multiple codebases, handy tool.

### Are there any dependencies or blockers for merging this?

This can go straight to master. I can then merge master into my webpack PR.

### How can we verify that this change works?

npm run test
