### PR TITLE
Fix 1 of 2 BabyHint banned properties bypass exploits

### DIFF
--- a/js/output/pjs/babyhint.js
+++ b/js/output/pjs/babyhint.js
@@ -139,7 +139,8 @@ var BabyHint = {
         location: true,
         document: true,
         ownerDocument: true,
-        createElement: true
+        createElement: true,
+        constructor: true // Can be used to bypass some circumventions
     },
 
     variables: [],

--- a/tests/output/pjs/jshint_test.js
+++ b/tests/output/pjs/jshint_test.js
@@ -108,6 +108,13 @@ describe("Scratchpad Output - BabyHint checks", function() {
         babyhint: true,
         code: "rect(100, 200, 300);"
     });
+    
+    assertTest({   
+        title: "Banned properties test",
+        reason: "constructor is a reserved word.",
+        babyhint: true,
+        code: "[].constructor.constructor('return 1');"
+    });
 });
 
 // Syntax errors - not controlled by JSHint options.
@@ -147,6 +154,7 @@ describe("Scratchpad Output - JSHint syntax errors", function() {
         code: "10"
     });
 
+    
     assertTest({
         title: "Not closing a string",
         reason: "Unclosed string! Make sure you end your string with a quote.",


### PR DESCRIPTION
### High-level description of change

I am fixing an exploit where a constructor chain from any Object can be used to circumvent security features. I created the ticket 228409 about this and another similar issue.
### Are there performance implications for this change?
I have not tested, but it should be very little (maybe a few ms at most.)
### Have you added tests to cover this new/updated code?

No tests have been added. I didn't see a test file for BabyHint in the test folder.

### Risks involved

If someone is attempting to define a property named "constructor" on any object, it may break some programs.

### Are there any dependencies or blockers for merging this?

No new dependencies are required.

### How can we verify that this change works?

Attempt to use a constructor to create a Function object, like this:

```[].constructor.constructor('console.log("Hi!");')();```
If an error appears through Oh Noes and nothing appears in the console, the change has worked.
