### PR TITLE
Add logFullScreen option 

### DIFF
--- a/build/js/live-editor.output.js
+++ b/build/js/live-editor.output.js
@@ -327,7 +327,7 @@ window.LiveEditorOutput = Backbone.View.extend({
         this.config = new ScratchpadConfig({});
 
         if (options.outputType) {
-            this.setOutput(options.outputType, true, options.loopProtectTimeouts);
+            this.setOutput(options.outputType, true, options.loopProtectTimeouts, options.logFullScreen);
         }
 
         // Add a timestamp property to the lintErrors and runtimeErrors arrays
@@ -354,7 +354,7 @@ window.LiveEditorOutput = Backbone.View.extend({
         window.addEventListener("message", this.handleMessage.bind(this), false);
     },
 
-    setOutput: function setOutput(outputType, enableLoopProtect, loopProtectTimeouts) {
+    setOutput: function setOutput(outputType, enableLoopProtect, loopProtectTimeouts, logFullScreen) {
         var OutputClass = this.outputs[outputType];
         this.output = new OutputClass({
             el: this.$el.find(".output"),
@@ -362,7 +362,8 @@ window.LiveEditorOutput = Backbone.View.extend({
             output: this,
             type: outputType,
             enableLoopProtect: enableLoopProtect,
-            loopProtectTimeouts: loopProtectTimeouts
+            loopProtectTimeouts: loopProtectTimeouts,
+            logFullScreen: logFullScreen
         });
     },
 
@@ -421,6 +422,7 @@ window.LiveEditorOutput = Backbone.View.extend({
         if (!this.output) {
             var outputType = data.outputType || _.keys(this.outputs)[0];
             var enableLoopProtect = true;
+            var logFullScreen = false;
             if (data.enableLoopProtect != null) {
                 enableLoopProtect = data.enableLoopProtect;
             }
@@ -431,7 +433,10 @@ window.LiveEditorOutput = Backbone.View.extend({
             if (data.loopProtectTimeouts != null) {
                 loopProtectTimeouts = data.loopProtectTimeouts;
             }
-            this.setOutput(outputType, enableLoopProtect, loopProtectTimeouts);
+            if (data.logFullScreen != null) {
+                logFullScreen = data.logFullScreen;
+            }
+            this.setOutput(outputType, enableLoopProtect, loopProtectTimeouts, logFullScreen);
         }
 
         // Set the paths from the incoming data, if they exist

--- a/build/js/live-editor.output_pjs.js
+++ b/build/js/live-editor.output_pjs.js
@@ -2814,6 +2814,9 @@ window.PJSOutput = Backbone.View.extend({
 
         this.processing = new Processing(canvas, function (instance) {
             instance.draw = _this.DUMMY;
+            if (_this.options.logFullScreen) {
+                instance.println("FULLSCREENLOG");
+            }
         });
 
         // The reason why we're passing the whole "output" object instead of
@@ -2872,6 +2875,7 @@ window.PJSOutput = Backbone.View.extend({
             // Restart execution
             this.output.restart();
         }
+        if (this.processing) {}
     },
 
     messageHandlers: {
@@ -3120,3 +3124,5 @@ LiveEditorOutput.registerOutput("pjs", PJSOutput);
 // Couldn't access property for permissions reasons,
 //  like window.frame
 // Only happens on prod where it's cross-origin
+
+// find log

--- a/build/js/live-editor.output_pjs.js
+++ b/build/js/live-editor.output_pjs.js
@@ -2875,7 +2875,6 @@ window.PJSOutput = Backbone.View.extend({
             // Restart execution
             this.output.restart();
         }
-        if (this.processing) {}
     },
 
     messageHandlers: {
@@ -3124,5 +3123,3 @@ LiveEditorOutput.registerOutput("pjs", PJSOutput);
 // Couldn't access property for permissions reasons,
 //  like window.frame
 // Only happens on prod where it's cross-origin
-
-// find log

--- a/build/js/live-editor.output_pjs_deps.js
+++ b/build/js/live-editor.output_pjs_deps.js
@@ -19715,7 +19715,8 @@
               if (height < 0) {
                 height = 0;
               } else if (height + resizerHeight > viewHeight) {
-                height = viewHeight - resizerHeight;
+                // subtract resizer height and bottom padding
+                height = viewHeight - resizerHeight - 5;
               }
 
               containerStyle.height = height / viewHeight * 100 + "%";
@@ -19792,6 +19793,11 @@
           docElem.insertBefore(container, docElem.firstChild);
 
           tinylogLite[log] = function(message) {
+            // If we intercept special message, display full-screen log
+            if (message === "FULLSCREENLOG") {
+              setContainerHeight(Infinity);
+              return;
+            }
             if (messages === logLimit) {
               output.removeChild(output.firstChild);
             } else {

--- a/build/js/live-editor.ui.js
+++ b/build/js/live-editor.ui.js
@@ -843,6 +843,7 @@ window.LiveEditor = Backbone.View.extend({
         } else {
             this.enableLoopProtect = true;
         }
+        this.logFullScreen = !!options.logFullScreen;
 
         // Set up the editor
         this.editor = new this.editors[this.editorType]({
@@ -2022,7 +2023,8 @@ window.LiveEditor = Backbone.View.extend({
             redirectUrl: this.redirectUrl,
             jshintFile: this.jshintFile,
             outputType: this.outputType,
-            enableLoopProtect: this.enableLoopProtect
+            enableLoopProtect: this.enableLoopProtect,
+            logFullScreen: this.logFullScreen
         };
 
         this.trigger("runCode", options);

--- a/demos/simple/index.html
+++ b/demos/simple/index.html
@@ -71,7 +71,7 @@
         execFile: outputUrl,
         jshintFile: "../../build/external/jshint/jshint.js",
         newErrorExperience: true,
-        logFullScreen: true
+        logFullScreen: false
     });
     liveEditor.editor.on("change", function() {
         window.localStorage["test-code"] = liveEditor.editor.text();

--- a/demos/simple/index.html
+++ b/demos/simple/index.html
@@ -71,6 +71,7 @@
         execFile: outputUrl,
         jshintFile: "../../build/external/jshint/jshint.js",
         newErrorExperience: true,
+        logFullScreen: true
     });
     liveEditor.editor.on("change", function() {
         window.localStorage["test-code"] = liveEditor.editor.text();

--- a/js/live-editor.js
+++ b/js/live-editor.js
@@ -117,6 +117,7 @@ window.LiveEditor = Backbone.View.extend({
         } else {
             this.enableLoopProtect = true;
         }
+        this.logFullScreen = !!options.logFullScreen;
 
         // Set up the editor
         this.editor = new this.editors[this.editorType]({
@@ -1335,7 +1336,8 @@ window.LiveEditor = Backbone.View.extend({
             redirectUrl: this.redirectUrl,
             jshintFile: this.jshintFile,
             outputType: this.outputType,
-            enableLoopProtect: this.enableLoopProtect
+            enableLoopProtect: this.enableLoopProtect,
+            logFullScreen: this.logFullScreen,
         };
 
         this.trigger("runCode", options);

--- a/js/output/pjs/pjs-output.js
+++ b/js/output/pjs/pjs-output.js
@@ -166,6 +166,9 @@ window.PJSOutput = Backbone.View.extend({
     build: function(canvas, enableLoopProtect, loopProtectTimeouts) {
         this.processing = new Processing(canvas, (instance) => {
             instance.draw = this.DUMMY;
+            if (this.options.logFullScreen) {
+              instance.println("FULLSCREENLOG");
+            }
         });
 
         // The reason why we're passing the whole "output" object instead of
@@ -225,6 +228,10 @@ window.PJSOutput = Backbone.View.extend({
 
             // Restart execution
             this.output.restart();
+        }
+        if (this.processing) {
+            // find log
+
         }
     },
 

--- a/js/output/pjs/pjs-output.js
+++ b/js/output/pjs/pjs-output.js
@@ -229,10 +229,6 @@ window.PJSOutput = Backbone.View.extend({
             // Restart execution
             this.output.restart();
         }
-        if (this.processing) {
-            // find log
-
-        }
     },
 
     messageHandlers: {

--- a/js/output/shared/output.js
+++ b/js/output/shared/output.js
@@ -17,7 +17,8 @@ window.LiveEditorOutput = Backbone.View.extend({
         this.config = new ScratchpadConfig({});
 
         if (options.outputType) {
-            this.setOutput(options.outputType, true, options.loopProtectTimeouts);
+            this.setOutput(options.outputType, true,
+                options.loopProtectTimeouts, options.logFullScreen);
         }
 
         // Add a timestamp property to the lintErrors and runtimeErrors arrays
@@ -45,7 +46,7 @@ window.LiveEditorOutput = Backbone.View.extend({
             this.handleMessage.bind(this), false);
     },
 
-    setOutput: function(outputType, enableLoopProtect, loopProtectTimeouts) {
+    setOutput: function(outputType, enableLoopProtect, loopProtectTimeouts, logFullScreen) {
         var OutputClass = this.outputs[outputType];
         this.output = new OutputClass({
             el: this.$el.find(".output"),
@@ -53,7 +54,8 @@ window.LiveEditorOutput = Backbone.View.extend({
             output: this,
             type: outputType,
             enableLoopProtect: enableLoopProtect,
-            loopProtectTimeouts: loopProtectTimeouts
+            loopProtectTimeouts: loopProtectTimeouts,
+            logFullScreen: logFullScreen,
         });
     },
 
@@ -112,6 +114,7 @@ window.LiveEditorOutput = Backbone.View.extend({
         if (!this.output) {
             var outputType = data.outputType || _.keys(this.outputs)[0];
             var enableLoopProtect = true;
+            var logFullScreen = false;
             if (data.enableLoopProtect != null) {
                 enableLoopProtect = data.enableLoopProtect;
             }
@@ -122,7 +125,10 @@ window.LiveEditorOutput = Backbone.View.extend({
             if (data.loopProtectTimeouts != null) {
                 loopProtectTimeouts = data.loopProtectTimeouts;
             }
-            this.setOutput(outputType, enableLoopProtect, loopProtectTimeouts);
+            if (data.logFullScreen != null) {
+                logFullScreen = data.logFullScreen;
+            }
+            this.setOutput(outputType, enableLoopProtect, loopProtectTimeouts, logFullScreen);
         }
 
         // Set the paths from the incoming data, if they exist


### PR DESCRIPTION
### High-level description of change

This PR adds a logFullScreen option to LiveEditor, which then gets passed to LiveEditorOutput and then to PJSOutput. It ultimately gets used to trigger a full-screen log after the Processing sketch loads. 

(See my related PR in processing-js repo: https://github.com/Khan/processing-js/pull/12)

This PR is 99% option forwarding.

### Are there performance implications for this change?

No, and will not be used by majority of programs anyway.

### Have you added tests to cover this new/updated code?

No. 

### Risks involved

There's the usual risk in adding a new option in that it adds slightly more complexity and maintenance burden.

### Are there any dependencies or blockers for merging this?

Yes, external/processing-js PR

### How can we verify that this change works?

Locally, I edited LiveEditor demos/simple/index.html to set logFullScreen to true and verified that worked. I also checked I could trigger the processingJS change by simply typing println("LOGFULLSCREEN").

There's no control for it in webapp yet, so only the latter test would work there.