### PR TITLE
Fixing visible logic for LoopProtect

### DIFF
--- a/build/js/live-editor.output_pjs_deps.js
+++ b/build/js/live-editor.output_pjs_deps.js
@@ -87486,6 +87486,7 @@ window.LoopProtector.prototype = {
                         _this2.callback(_error);
                         throw _error;
                     }
+
                     // Determine which of KAInfiniteLoopProtect's callsites has
                     // the most calls.
                     var max = 0; // current max count

--- a/build/js/live-editor.output_pjs_deps.js
+++ b/build/js/live-editor.output_pjs_deps.js
@@ -87436,7 +87436,7 @@ window.LoopProtector = function (callback, timeouts, reportLocation) {
     this.KAInfiniteLoopSetTimeout = this._KAInfiniteLoopSetTimeout.bind(this);
 
     document.addEventListener("visibilitychange", function () {
-        if (document.hidden) {
+        if (!document.hidden) {
             _this.visible = true;
             _this.branchStartTime = 0;
         } else {
@@ -87486,7 +87486,6 @@ window.LoopProtector.prototype = {
                         _this2.callback(_error);
                         throw _error;
                     }
-
                     // Determine which of KAInfiniteLoopProtect's callsites has
                     // the most calls.
                     var max = 0; // current max count

--- a/build/js/live-editor.output_webpage_deps.js
+++ b/build/js/live-editor.output_webpage_deps.js
@@ -11923,7 +11923,7 @@ window.LoopProtector = function (callback, timeouts, reportLocation) {
     this.KAInfiniteLoopSetTimeout = this._KAInfiniteLoopSetTimeout.bind(this);
 
     document.addEventListener("visibilitychange", function () {
-        if (document.hidden) {
+        if (!document.hidden) {
             _this.visible = true;
             _this.branchStartTime = 0;
         } else {
@@ -11973,7 +11973,6 @@ window.LoopProtector.prototype = {
                         _this2.callback(_error);
                         throw _error;
                     }
-
                     // Determine which of KAInfiniteLoopProtect's callsites has
                     // the most calls.
                     var max = 0; // current max count

--- a/build/js/live-editor.output_webpage_deps.js
+++ b/build/js/live-editor.output_webpage_deps.js
@@ -11973,6 +11973,7 @@ window.LoopProtector.prototype = {
                         _this2.callback(_error);
                         throw _error;
                     }
+
                     // Determine which of KAInfiniteLoopProtect's callsites has
                     // the most calls.
                     var max = 0; // current max count

--- a/js/output/shared/loop-protect.js
+++ b/js/output/shared/loop-protect.js
@@ -28,7 +28,7 @@ window.LoopProtector = function(callback, timeouts, reportLocation) {
     this.KAInfiniteLoopSetTimeout = this._KAInfiniteLoopSetTimeout.bind(this);
 
     document.addEventListener('visibilitychange', () => {
-        if (document.hidden) {
+        if (!document.hidden) {
             this.visible = true;
             this.branchStartTime = 0;
         } else {
@@ -75,7 +75,6 @@ window.LoopProtector.prototype = {
                     this.callback(error);
                     throw error;
                 }
-
                 // Determine which of KAInfiniteLoopProtect's callsites has
                 // the most calls.
                 let max = 0;            // current max count

--- a/js/output/shared/loop-protect.js
+++ b/js/output/shared/loop-protect.js
@@ -75,6 +75,7 @@ window.LoopProtector.prototype = {
                     this.callback(error);
                     throw error;
                 }
+
                 // Determine which of KAInfiniteLoopProtect's callsites has
                 // the most calls.
                 let max = 0;            // current max count


### PR DESCRIPTION
### High-level description of change

In PR #670, I replaced the visibly library with the native visibilitychange event. Sadly, when I did that, I reversed the logic for setting visible after a visibilitychange. This meant that if you changed tabs after starting to code in the editor and _then_ introduced an infinite loop, the tab would crash. Sad! :( :(
(Hopefully most students reloaded in a new tab and were okay, so perhaps that's why we didn't see a huge number of reports caused by this regression).

This PR adds a single character to fix the bug.

### Have you added tests to cover this new/updated code?

No, there are no tests that test the visibility change. It may be possible to mock it but that'd add a lot of time to this fix.

### Risks involved

This should bring it back to its previous functional state, so it should be low risk. 

### How can we verify that this change works?

Open the local demo. Paste this code:

for (var i = 0; i < 10;) {
   
}

See that the loop error pops up.

Now delete i < 10; in that code.

Switch to any other tab, switch back.

Paste in the code again. 

See that the loop error pops up after a second of thinking.

Once deployed into webapp, a great place to test is Loopy Ruler, as that's where students have run into it.

<img width="899" alt="screen shot 2019-02-13 at 11 44 56 am" src="https://user-images.githubusercontent.com/297042/52739038-e2df8a00-2f84-11e9-8b0a-30fe4e25230c.png">
