### PR TITLE
Typo: fix x to x1

### DIFF
--- a/build/js/live-editor.tooltips.js
+++ b/build/js/live-editor.tooltips.js
@@ -832,7 +832,7 @@ window.ScratchpadAutosuggestData = {
             name: "triangle(x1, y1, x2, y2, x3, y3)",
             exampleURL: "/cs/trianglex1-y1-x2-y2-x3-y3/839546599",
             description: i18n._("Draws a triangle"),
-            params: [i18n._("x: the x-coordinate of the first vertex"), i18n._("y1: the y-coordinate of the first vertex"), i18n._("x2: the x-coordinate of the second vertex"), i18n._("y2: the y-coordinate of the second vertex"), i18n._("x3: the x-coordinate of the third vertex"), i18n._("y3: the y-coordinate of the third vertex")]
+            params: [i18n._("x1: the x-coordinate of the first vertex"), i18n._("y1: the y-coordinate of the first vertex"), i18n._("x2: the x-coordinate of the second vertex"), i18n._("y2: the y-coordinate of the second vertex"), i18n._("x3: the x-coordinate of the third vertex"), i18n._("y3: the y-coordinate of the third vertex")]
         }, {
             name: "line(x1, y1, x2, y2)",
             exampleURL: "/cs/linex1-y1-x2-y2/827916099",

--- a/js/ui/autosuggest-data.js
+++ b/js/ui/autosuggest-data.js
@@ -47,7 +47,7 @@ window.ScratchpadAutosuggestData = {
                 exampleURL: "/cs/trianglex1-y1-x2-y2-x3-y3/839546599",
                 description: i18n._("Draws a triangle"),
                 params: [
-                    i18n._("x: the x-coordinate of the first vertex"),
+                    i18n._("x1: the x-coordinate of the first vertex"),
                     i18n._("y1: the y-coordinate of the first vertex"),
                     i18n._("x2: the x-coordinate of the second vertex"),
                     i18n._("y2: the y-coordinate of the second vertex"),


### PR DESCRIPTION
### High-level description of change

Changes "x" to "x1". This was a Crowdin-reported error.

### How can we verify that this change works?

Type triangle( into a program, see autocomplete pop up, hover over x1, see that it says x1 and not x.
