### PR TITLE
Disable same-source postMessage inside output

### DIFF
--- a/build/js/live-editor.output.js
+++ b/build/js/live-editor.output.js
@@ -493,14 +493,13 @@ window.LiveEditorOutput = Backbone.View.extend({
         // Then we don't need to care about sending the messages anywhere!
         if (this.frameSource) {
             var parentWindow = this.frameSource;
-            // In Chrome on dev when postFrame is called from webapp's
-            // scratchpad package it is somehow executed from the iframe
-            // instead, so frameSource is not really the parent frame.  We
-            // detect that here and fix it.
-            // TODO(james): Figure out why this is and if there is a better
-            // place to put a fix.
+            // Ignore any attempts to send a message to the same window
+            // NOTE(jeresig): Ideally we'd queue up these messages until
+            // we have a valid frameSource & frameOrigin and then send all
+            // the messages at that time. In practice this doesn't seem to
+            // be a problem, however.
             if (this.frameSource === window) {
-                parentWindow = this.frameSource.parent;
+                return;
             }
 
             parentWindow.postMessage(typeof data === "string" ? data : JSON.stringify(data), this.frameOrigin);

--- a/js/output/shared/output.js
+++ b/js/output/shared/output.js
@@ -184,14 +184,13 @@ window.LiveEditorOutput = Backbone.View.extend({
         // Then we don't need to care about sending the messages anywhere!
         if (this.frameSource) {
             let parentWindow = this.frameSource;
-            // In Chrome on dev when postFrame is called from webapp's
-            // scratchpad package it is somehow executed from the iframe
-            // instead, so frameSource is not really the parent frame.  We
-            // detect that here and fix it.
-            // TODO(james): Figure out why this is and if there is a better
-            // place to put a fix.
+            // Ignore any attempts to send a message to the same window
+            // NOTE(jeresig): Ideally we'd queue up these messages until
+            // we have a valid frameSource & frameOrigin and then send all
+            // the messages at that time. In practice this doesn't seem to
+            // be a problem, however.
             if (this.frameSource === window) {
-                parentWindow = this.frameSource.parent;
+                return;
             }
 
             parentWindow.postMessage(


### PR DESCRIPTION
Test Plan:
It's really hard to test this in dev, it requires different frame origins. Will attempt to test this in production. At least with this change it should be possible to load a CS page and not see an error in the console.

Additionally, CS challenges should continue to work (they use a lot of postMessages so it's a good confirmation).

### High-level description of change

_REPLACE THIS: Describe what bug you're fixing. (We are not currently adding features).
Reference the issue number or ZenDesk ticket if one exists._

### Are there performance implications for this change?

_REPLACE THIS: Please profile using time/timeEnd any potentially time-taking changes.
Then profile using node profiler to identify what aspects take most time._

### Have you added tests to cover this new/updated code?

_REPLACE THIS: Note what tests you added, and if tests aren't possible, explain why not._

### Risks involved

_REPLACE THIS: Note anything that could go wrong. Good opportunity to think through edge cases._

### Are there any dependencies or blockers for merging this?

_REPLACE THIS: Note any branches that must be merged elsewhere._

### How can we verify that this change works?

_REPLACE THIS: Describe how we can check this change works for the user from end to end, like with example programs._
