### PR TITLE
Make SQL 'ambiguous column name' error translatable

### DIFF
--- a/build/js/live-editor.output_sql.js
+++ b/build/js/live-editor.output_sql.js
@@ -838,6 +838,12 @@ window.SQLOutput = Backbone.View.extend({
             var colName = errorMessage.split(dupColStr)[1].trim();
             errorMessage = i18n._("You have multiple columns named \"%(colName)s\" - " + "column names must be unique.", { colName: colName });
         }
+        var ambColStr = "ambiguous column name:";
+        var ambColError = sqliteError.indexOf(ambColStr) > -1;
+        if (ambColError) {
+            var colName = errorMessage.split(ambColStr)[1].trim();
+            errorMessage = i18n._("Ambiguous column name \"%(colName)s\".", { colName: colName });
+        }
         var unknownColStr = "no such column:";
         var unknownColError = sqliteError.indexOf(unknownColStr) > -1;
         if (unknownColError) {

--- a/js/output/sql/sql-output.js
+++ b/js/output/sql/sql-output.js
@@ -96,6 +96,13 @@ window.SQLOutput = Backbone.View.extend({
             errorMessage = i18n._("You have multiple columns named \"%(colName)s\" - " +
                 "column names must be unique.", {colName});
         }
+        const ambColStr = "ambiguous column name:";
+        const ambColError = sqliteError.indexOf(ambColStr) > -1;
+        if (ambColError) {
+            const colName = errorMessage.split(ambColStr)[1].trim();
+            errorMessage = i18n._("Ambiguous column name \"%(colName)s\".",
+                {colName});
+        }
         const unknownColStr = "no such column:";
         const unknownColError = sqliteError.indexOf(unknownColStr) > -1;
         if (unknownColError) {


### PR DESCRIPTION
### High-level description of change

The errors thrown by SQLite are parsed individually and made more user-friendly and marked for translations. This one particular error -- `ambiguous column name` -- is not handled, which means the corresponding string cannot be translated into other langs on Khan. This commit fixes that. Also, I'll try to make the text more helpful, but I am not an SQL expert so this needs to be reviewed.

Tracking JIRA ticket: [IC-527](https://khanacademy.atlassian.net/browse/IC-527)

### Are there performance implications for this change?

Minimal. 

### Have you added tests to cover this new/updated code?

Not sure whether there are existing tests for this functionality.

### Risks involved

I simply copied the existing code and only changed a couple of strings and variable names, hopefully, it should be safe.

### Are there any dependencies or blockers for merging this?

Nope.

### How can we verify that this change works?

1. run: `python -m SimpleHTTPServer`
2. Go to: http://0.0.0.0:8000/demos/simple/sql.html
3. This SQL should trigger the error, you can verify that the new text appears instead of the old one.
```sql
CREATE TABLE students (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, grade_year INTEGER NOT NULL);
CREATE TABLE student_grades (id INTEGER, grade INTEGER);
INSERT INTO students VALUES (1, "Brian", 3);
INSERT INTO student_grades VALUES (1, 95);
SELECT id FROM students INNER JOIN student_grades on students.id = student_grades.id;
```

