### PR TITLE
Check that iFrame content window exists before calling postMessage

### DIFF
--- a/build/js/live-editor.ui.js
+++ b/build/js/live-editor.ui.js
@@ -1983,7 +1983,10 @@ window.LiveEditor = Backbone.View.extend({
 
     postFrame: function postFrame(data) {
         // Send the data to the frame using postMessage
-        this.$el.find("#output-frame")[0].contentWindow.postMessage(JSON.stringify(data), this.postFrameOrigin());
+        var outputFrameWindow = this.$el.find("#output-frame")[0].contentWindow;
+        if (outputFrameWindow) {
+            outputFrameWindow.postMessage(JSON.stringify(data), this.postFrameOrigin());
+        }
     },
 
     hasFrame: function hasFrame() {

--- a/build/js/live-editor.ui.js
+++ b/build/js/live-editor.ui.js
@@ -1983,10 +1983,7 @@ window.LiveEditor = Backbone.View.extend({
 
     postFrame: function postFrame(data) {
         // Send the data to the frame using postMessage
-        var outputFrameWindow = this.$el.find("#output-frame")[0].contentWindow;
-        if (outputFrameWindow) {
-            outputFrameWindow.postMessage(JSON.stringify(data), this.postFrameOrigin());
-        }
+        this.$el.find("#output-frame")[0].contentWindow.postMessage(JSON.stringify(data), this.postFrameOrigin());
     },
 
     hasFrame: function hasFrame() {

--- a/js/live-editor.js
+++ b/js/live-editor.js
@@ -1295,8 +1295,10 @@ window.LiveEditor = Backbone.View.extend({
 
     postFrame: function(data) {
         // Send the data to the frame using postMessage
-        this.$el.find("#output-frame")[0].contentWindow.postMessage(
-            JSON.stringify(data), this.postFrameOrigin());
+        var outputFrameWindow = this.$el.find("#output-frame")[0].contentWindow;
+        if (outputFrameWindow) {
+            outputFrameWindow.postMessage(JSON.stringify(data), this.postFrameOrigin());
+        }
     },
 
     hasFrame: function() {


### PR DESCRIPTION
### High-level description of change

There are many "Cannot read property 'postMessage' of null" error messages on production tracing back to this line. This error is reproducible on production when switching quickly between scratchpad and non-scratchpad lessons.

### Are there performance implications for this change?

No.

### Have you added tests to cover this new/updated code?

Cannot reproduce locally--seems to be a timing issue on prod.

### Risks involved

None

### Are there any dependencies or blockers for merging this?

None

### How can we verify that this change works?

By testing in production.
