### PR TITLE
Making loop messages translatable

### DIFF
--- a/build/js/live-editor.ui.js
+++ b/build/js/live-editor.ui.js
@@ -2184,11 +2184,11 @@ window.LiveEditor = Backbone.View.extend({
 
     cleanErrors: function cleanErrors(errors) {
         var loopProtectMessages = {
-            "WhileStatement": i18n._("<code>while</code> loop"),
-            "DoWhileStatement": i18n._("<code>do-while</code> loop"),
-            "ForStatement": i18n._("<code>for</code> loop"),
-            "FunctionDeclaration": i18n._("<code>function</code>"),
-            "FunctionExpression": i18n._("<code>function</code>")
+            "WhileStatement": i18n._("A <code>while</code> loop is taking too long to run."),
+            "DoWhileStatement": i18n._("A <code>do-while</code> loop is taking too long to run."),
+            "ForStatement": i18n._("A <code>for</code> loop is taking too long to run."),
+            "FunctionDeclaration": i18n._("A <code>function</code> is taking too long to run."),
+            "FunctionExpression": i18n._("A <code>function</code> is taking too long to run.")
         };
 
         errors = errors.map((function (error) {
@@ -2204,8 +2204,8 @@ window.LiveEditor = Backbone.View.extend({
             // appropriately sanitized.
             var loopNodeType = error.infiniteLoopNodeType;
             if (loopNodeType) {
-                error.html = i18n._("A %(type)s is taking too long to run. " + "Perhaps you have a mistake in your code?", {
-                    type: loopProtectMessages[loopNodeType]
+                error.html = i18n._("%(typeMessage)s " + "Perhaps you have a mistake in your code?", {
+                    typeMessage: loopProtectMessages[loopNodeType]
                 });
             }
 

--- a/js/live-editor.js
+++ b/js/live-editor.js
@@ -1494,11 +1494,11 @@ window.LiveEditor = Backbone.View.extend({
 
     cleanErrors: function(errors) {
         var loopProtectMessages = {
-            "WhileStatement": i18n._("<code>while</code> loop"),
-            "DoWhileStatement": i18n._("<code>do-while</code> loop"),
-            "ForStatement": i18n._("<code>for</code> loop"),
-            "FunctionDeclaration": i18n._("<code>function</code>"),
-            "FunctionExpression": i18n._("<code>function</code>"),
+            "WhileStatement": i18n._("A <code>while</code> loop is taking too long to run."),
+            "DoWhileStatement": i18n._("A <code>do-while</code> loop is taking too long to run."),
+            "ForStatement": i18n._("A <code>for</code> loop is taking too long to run."),
+            "FunctionDeclaration": i18n._("A <code>function</code> is taking too long to run."),
+            "FunctionExpression": i18n._("A <code>function</code> is taking too long to run."),
         };
 
         errors = errors.map(function(error) {
@@ -1515,9 +1515,9 @@ window.LiveEditor = Backbone.View.extend({
             var loopNodeType = error.infiniteLoopNodeType;
             if (loopNodeType) {
                 error.html = i18n._(
-                    "A %(type)s is taking too long to run. " +
+                    "%(typeMessage)s " +
                     "Perhaps you have a mistake in your code?", {
-                        type: loopProtectMessages[loopNodeType]
+                        typeMessage: loopProtectMessages[loopNodeType]
                 });
             }
 


### PR DESCRIPTION
### High-level description of change

Addresses https://khanacademy.atlassian.net/browse/CTI-307: it is difficult to translate the loop checker message into gendered languages like Spanish where function and loop have different genders. 

This makes the message for each construct a separate sentence, for ultimate translatability across languages. Please do let me know if there's a slicker way to do this with i18n._().

### Are there performance implications for this change?

No.

### Have you added tests to cover this new/updated code?

No, the loop protector tests don't currently test the message output itself.

### Risks involved

Weird spacing? I wasn't sure the best way to ensure a space between the first sentence and the second. 
Also, we will likely lose any current translations.

### Are there any dependencies or blockers for merging this?

No.

### How can we verify that this change works?

Open demos/simple.html, write an infinite loop, see message pop up. Do same on cs/new/pjs once this is in webapp.
