### PR TITLE
Remove use of API from simple demo

### DIFF
--- a/demos/simple/index.html
+++ b/demos/simple/index.html
@@ -37,26 +37,6 @@
 
     var code = window.localStorage["test-code"] || "rect(10, 10, 100, 100);";
 
-    var search = location.search.substring(1);
-    var params = {};
-    search.split("&").forEach(function(param) {
-        var tokens = param.split("=");
-        params[tokens[0]] = tokens[1];
-    });
-
-    if (params.scratchpad) {
-        var xhr = new XMLHttpRequest();
-        var baseUrl = "https://www.khanacademy.org/api/internal/scratchpads/";
-        xhr.open("GET", baseUrl + params.scratchpad, false);
-        xhr.addEventListener("load", function() {
-            var scratchpad = JSON.parse(this.responseText);
-            code = scratchpad.revision.code;
-            var h1 = document.querySelector('h1');
-            h1.innerText = scratchpad.title;
-        });
-        xhr.send();
-    }
-
     window.liveEditor = new LiveEditor({
         el: $("#sample-live-editor"),
         code: code,


### PR DESCRIPTION
### High-level description of change

The Khan Academy API endpoints will be going away in 2020, per the khan-api deprecation notice: https://github.com/Khan/khan-api
This PR removes use of the API from the simple demo. It was used to load in a program based on datastore ID. That is not necessary for testing the live-editor code.

### Are there performance implications for this change?

No

### Have you added tests to cover this new/updated code?

No, this is just a change to the demo.

### Risks involved

None

### Are there any dependencies or blockers for merging this?

None

### How can we verify that this change works?

Run the simple server, open localhost/demos/simple/, see editor loads and you can type PJS code.
