### PR TITLE
Make SQL error translatable

### DIFF
--- a/build/js/live-editor.output_sql.js
+++ b/build/js/live-editor.output_sql.js
@@ -861,6 +861,32 @@ window.SQLOutput = Backbone.View.extend({
             var nearPhrase = errorMessage.split(syntaxErrStr)[0];
             errorMessage = i18n._("There's a syntax error near %(nearThing)s.", { nearThing: nearPhrase.substr(5) });
         }
+        var colValueMismatchReg = /has (\d+) columns but (\d+) values were supplied/;
+        var colMismatchError = sqliteError.match(colValueMismatchReg);
+        if (colMismatchError) {
+            var tableName = sqliteError.split(" ")[1];
+            var numCols = colMismatchError[1];
+            var numVals = colMismatchError[2];
+
+            // I18N: The first part of "Oh noes" error in the SQL course.
+            // I18N: "Table %(tableName)s has %(num)s columns"
+            // I18N: "but %(num)s values were supplied."
+            // I18N: You can reorder the parts in string "%(columns)s %(values)s"
+            var tableHasColumns = i18n.ngettext("Table \"%(tableName)s\" has %(num)s column", "Table \"%(tableName)s\" has %(num)s columns", numCols, { tableName: tableName });
+
+            // I18N: The second part of "Oh noes" error in the SQL course.
+            // I18N: "Table %(tableName)s has %(num)s columns"
+            // I18N: "but %(num)s values were supplied."
+            // I18N: You can reorder the parts in string "%(columns)s %(values)s"
+            var valuesSupplied = i18n.ngettext("but %(num)s value was supplied.", "but %(num)s values were supplied.", numVals);
+
+            // I18N: Oh noes error in the SQL course.
+            // I18N: %(columns)s = "Table %(tableName)s has %(num)s columns"
+            // I18N: %(values)s  = "but %(num)s values were supplied."
+            // I18N: The sentences are translated in two different Crowdin strings,
+            // I18N: but can be reordered here
+            errorMessage = i18n._("%(columns)s %(values)s", { columns: tableHasColumns, values: valuesSupplied });
+        }
 
         // Now that we've translated the base error messages,
         // we add on additional helper messages for common mistakes

--- a/js/output/sql/sql-output.js
+++ b/js/output/sql/sql-output.js
@@ -122,6 +122,39 @@ window.SQLOutput = Backbone.View.extend({
             errorMessage = i18n._("There's a syntax error near %(nearThing)s.",
                 {nearThing: nearPhrase.substr(5)});
         }
+        const colValueMismatchReg = /has (\d+) columns but (\d+) values were supplied/;
+        const colMismatchError = sqliteError.match(colValueMismatchReg);
+        if (colMismatchError) {
+          const tableName = sqliteError.split(" ")[1];
+          const numCols = colMismatchError[1];
+          const numVals = colMismatchError[2];
+
+          // I18N: The first part of "Oh noes" error in the SQL course.
+          // I18N: "Table %(tableName)s has %(num)s columns"
+          // I18N: "but %(num)s values were supplied."
+          // I18N: You can reorder the parts in string "%(columns)s %(values)s"
+          const tableHasColumns = i18n.ngettext(
+              "Table \"%(tableName)s\" has %(num)s column",
+              "Table \"%(tableName)s\" has %(num)s columns",
+              numCols, {tableName: tableName});
+
+          // I18N: The second part of "Oh noes" error in the SQL course.
+          // I18N: "Table %(tableName)s has %(num)s columns"
+          // I18N: "but %(num)s values were supplied."
+          // I18N: You can reorder the parts in string "%(columns)s %(values)s"
+          const valuesSupplied = i18n.ngettext(
+              "but %(num)s value was supplied.",
+              "but %(num)s values were supplied.",
+              numVals);
+
+          // I18N: Oh noes error in the SQL course.
+          // I18N: %(columns)s = "Table %(tableName)s has %(num)s columns"
+          // I18N: %(values)s  = "but %(num)s values were supplied."
+          // I18N: The sentences are translated in two different Crowdin strings,
+          // I18N: but can be reordered here
+          errorMessage = i18n._("%(columns)s %(values)s",
+              {columns: tableHasColumns, values: valuesSupplied});
+        }
 
         // Now that we've translated the base error messages,
         // we add on additional helper messages for common mistakes

--- a/tests/output/sql/output_test.js
+++ b/tests/output/sql/output_test.js
@@ -56,6 +56,14 @@ describe("Linting", function() {
     failingTest("Inserting rows mismatching quote",
         "INSERT characters ('Summer);",
         ["There's a syntax error near \"characters\"."]);
+    failingTest("Inserting rows one column two values",
+        "CREATE TABLE characters (name TEXT);" +
+        "INSERT INTO characters VALUES (\"Beth\", \"Summer\");",
+        ["Table \"characters\" has 1 column but 2 values were supplied."]);
+    failingTest("Inserting rows two columns one value",
+        "CREATE TABLE characters (name TEXT, surname TEXT);" +
+        "INSERT INTO characters VALUES (\"Beth\");",
+        ["Table \"characters\" has 2 columns but 1 value was supplied."]);
 
     // Linting for select statements
     test("Simple select",

--- a/tests/output/webpage/output_test.js
+++ b/tests/output/webpage/output_test.js
@@ -266,6 +266,8 @@ describe("Linting", function() {
     if (!isFirefox()) {
         // An exception occurs in slowparse when parsing this HTML on
         // Chrome, Safari, and phantomjs.
+        // NOTE(danielhollas,pamelafox):
+        // This test seems to be failing on local machines
         failingTest("Fatal slowparse error detected",
             "<li><a href='</li><img src='https://www.kasandbox.org'>", [
                 {row: 0, column: 0, lint: {type: "UNKNOWN_SLOWPARSE_ERROR"}}


### PR DESCRIPTION
### High-level description of change

Fixing untranslatable SQL error string coming originally from SQLite. (same issue as in #717).

`table XX has X columns but Y values were supplied`

JIRA: [IC-611](https://khanacademy.atlassian.net/browse/IC-611)

This PR enhances the English output as well since it was not properly pluralized in SQLite.

### Are there performance implications for this change?

No.

### Have you added tests to cover this new/updated code?

Yes. I've also added a test covering #717.

### Risks involved

I hope that the approach for i18nizing this sentence is correct and will generate correct strings on Crowdin. :crossed_fingers: 

### Are there any dependencies or blockers for merging this?

No.

### How can we verify that this change works?

1. Play with the number of values in the following INSERT commands, verify the error is printed and pluralized correctly for different number of columns and values.

```sql
CREATE TABLE students (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, grade_year INTEGER NOT NULL);
CREATE TABLE student_grades (id INTEGER);

INSERT INTO student_grades VALUES (1);
INSERT INTO students VALUES (1, "sal", 1);
```

2. When this lands, verify that the new Crowdin strings are properly pluralized.
