### PR TITLE
Rewrite function declarations

### DIFF
--- a/build/js/live-editor.output_pjs.js
+++ b/build/js/live-editor.output_pjs.js
@@ -1027,6 +1027,8 @@ var PJSCodeInjector = (function () {
             } else {
                 astTransformPasses.push(ASTTransforms.checkForBannedProps(["__env__"]));
             }
+            // rewriteFunctionDeclarations turns function x() into var x = function
+            astTransformPasses.push(ASTTransforms.rewriteFunctionDeclarations);
 
             // loopProtector adds LoopProtector code which checks how long it's
             // taking to run event loop and will throw if it's taking too long.
@@ -1973,8 +1975,6 @@ var BabyHint = {
 
             // Checks could detect new errors, thus must run on every line
             errors = errors
-            // check for incorrect function declarations
-            .concat(BabyHint.checkFunctionDecl(line, lineNumber))
             // we don't allow ending lines with "="
             .concat(BabyHint.checkTrailingEquals(line, lineNumber))
             // check for correct number of parameters

--- a/build/js/live-editor.output_pjs_deps.js
+++ b/build/js/live-editor.output_pjs_deps.js
@@ -87854,3 +87854,27 @@ ASTTransforms.rewriteNewExpressions = function (envName) {
         }
     };
 };
+
+ASTTransforms.rewriteFunctionDeclarations = {
+    leave: function leave(node, path) {
+        if (node.type === "FunctionDeclaration") {
+            var decl = {
+                type: "VariableDeclarator",
+                id: {
+                    type: "Identifier",
+                    name: node.id.name
+                },
+                init: {
+                    type: "FunctionExpression",
+                    id: null,
+                    params: node.params,
+                    body: node.body,
+                    generator: node.generator,
+                    expression: node.expression,
+                    async: node.async
+                }
+            };
+            return b.VariableDeclaration([decl], "var");
+        }
+    }
+};

--- a/js/output/pjs/babyhint.js
+++ b/js/output/pjs/babyhint.js
@@ -218,8 +218,6 @@ var BabyHint = {
 
             // Checks could detect new errors, thus must run on every line
             errors = errors
-                // check for incorrect function declarations
-                .concat(BabyHint.checkFunctionDecl(line, lineNumber))
                 // we don't allow ending lines with "="
                 .concat(BabyHint.checkTrailingEquals(line, lineNumber))
                 // check for correct number of parameters

--- a/js/output/pjs/pjs-ast-transforms.js
+++ b/js/output/pjs/pjs-ast-transforms.js
@@ -318,3 +318,29 @@ ASTTransforms.rewriteNewExpressions = function(envName) {
         }
     }
 };
+
+
+
+ASTTransforms.rewriteFunctionDeclarations = {
+    leave(node, path) {
+        if (node.type === "FunctionDeclaration") {
+            var decl = {
+                type: "VariableDeclarator",
+                id: {
+                    type: "Identifier",
+                    name: node.id.name
+                },
+                init: {
+                    type: "FunctionExpression",
+                    id: null,
+                    params: node.params,
+                    body: node.body,
+                    generator: node.generator,
+                    expression: node.expression,
+                    async: node.async
+                }
+            };
+            return b.VariableDeclaration([decl], "var");
+        }
+    }
+};

--- a/js/output/pjs/pjs-code-injector.js
+++ b/js/output/pjs/pjs-code-injector.js
@@ -982,6 +982,8 @@ class PJSCodeInjector {
                 "__env__"
             ]));
         }
+        // rewriteFunctionDeclarations turns function x() into var x = function
+        astTransformPasses.push(ASTTransforms.rewriteFunctionDeclarations);
 
         // loopProtector adds LoopProtector code which checks how long it's
         // taking to run event loop and will throw if it's taking too long.

--- a/tests/output/webpage/output_test.js
+++ b/tests/output/webpage/output_test.js
@@ -263,24 +263,11 @@ describe("Linting", function() {
         ]
     );
 
-    if (!isFirefox()) {
-        // An exception occurs in slowparse when parsing this HTML on
-        // Chrome, Safari, and phantomjs.
-        failingTest("Fatal slowparse error detected",
-            "<li><a href='</li><img src='https://www.kasandbox.org'>", [
-                {row: 0, column: 0, lint: {type: "UNKNOWN_SLOWPARSE_ERROR"}}
-            ]
-        );
-    }
-
-    if (isFirefox()) {
-        // slowparse succeeds when parsing this HTML on Firefox.
-        failingTest("Not so fatal slowparse error detected (Firefox)",
-            "<li><a href='</li><img src='https://www.kasandbox.org'>", [
-                {row: 0, column: 7, lint: {type: "INVALID_ATTR_NAME"}}
-            ]
-        );
-    }
+    failingTest("Slowparse error detected",
+        "<li><a href='</li><img src='https://www.kasandbox.org'>", [
+            {row: 0, column: 7, lint: {type: "INVALID_ATTR_NAME"}}
+        ]
+    );
 
     //Scripting
     test("Script element enabled",

--- a/tests/output/webpage/output_test.js
+++ b/tests/output/webpage/output_test.js
@@ -263,11 +263,24 @@ describe("Linting", function() {
         ]
     );
 
-    failingTest("Slowparse error detected",
-        "<li><a href='</li><img src='https://www.kasandbox.org'>", [
-            {row: 0, column: 7, lint: {type: "INVALID_ATTR_NAME"}}
-        ]
-    );
+    if (!isFirefox()) {
+        // An exception occurs in slowparse when parsing this HTML on
+        // Chrome, Safari, and phantomjs.
+        failingTest("Fatal slowparse error detected",
+            "<li><a href='</li><img src='https://www.kasandbox.org'>", [
+                {row: 0, column: 7, lint: {type: "UNKNOWN_SLOWPARSE_ERROR"}}
+            ]
+        );
+    }
+
+    if (isFirefox()) {
+        // slowparse succeeds when parsing this HTML on Firefox.
+        failingTest("Slowparse error detected (Firefox)",
+            "<li><a href='</li><img src='https://www.kasandbox.org'>", [
+                {row: 0, column: 7, lint: {type: "INVALID_ATTR_NAME"}}
+            ]
+        );
+    }
 
     //Scripting
     test("Script element enabled",

--- a/tests/output/webpage/output_test.js
+++ b/tests/output/webpage/output_test.js
@@ -268,14 +268,14 @@ describe("Linting", function() {
         // Chrome, Safari, and phantomjs.
         failingTest("Fatal slowparse error detected",
             "<li><a href='</li><img src='https://www.kasandbox.org'>", [
-                {row: 0, column: 7, lint: {type: "UNKNOWN_SLOWPARSE_ERROR"}}
+                {row: 0, column: 0, lint: {type: "UNKNOWN_SLOWPARSE_ERROR"}}
             ]
         );
     }
 
     if (isFirefox()) {
         // slowparse succeeds when parsing this HTML on Firefox.
-        failingTest("Slowparse error detected (Firefox)",
+        failingTest("Not so fatal slowparse error detected (Firefox)",
             "<li><a href='</li><img src='https://www.kasandbox.org'>", [
                 {row: 0, column: 7, lint: {type: "INVALID_ATTR_NAME"}}
             ]


### PR DESCRIPTION
### High-level description of change

This rewrites function declarations into variable declarations. It does the rewriting when all the other rewriting is done, which happens after linting and tests are run.

The goal is that I can write examples for AP CSP that use function declaration syntax, as that is more compatible with how Code.org students are learning functions. That makes it easier for Code.org students/teachers to use the KA materials for remote learning.

### Are there performance implications for this change?

It's one more check while walking the AST. Should be negligible?

### Have you added tests to cover this new/updated code?

Yes, I added several in ast-transform. Happy to add any more edge cases you can think of.

### Risks involved

I think the AP CSP examples would be fine/not risky, I can put this on a ZND to see.
However, If other people start using this syntax, they may run into unforeseen issues with it: interaction with real-time update, interaction with challenge graders, etc. If they do run into issues, I disabled the babyhint so they would not see any message that'd indicate why something went awry.

Do you think this could put programs at risk somehow that aren't using function declarations? (Are there nodes with type=FunctionDeclaration besides what I'm testing?)

### Are there any dependencies or blockers for merging this?

webapp would need to be updated upstream

### How can we verify that this change works?

Try this program, see rect and ellipse:

```
function dry(x, y) {
    function innerFunc(x, y) {
        ellipse(x, y, 16, 13);
    }
    rect(x, y, 167, 137);
    innerFunc(102, 88);
}

dry(120, 95);

```