### PR TITLE
WIP: Trying to fix i18n pluralization of row/rows

### DIFF
--- a/build/js/live-editor.output_sql.js
+++ b/build/js/live-editor.output_sql.js
@@ -7,78 +7,60 @@ window["Handlebars"]["templates"]["sql-results"] = Handlebars.template({"1":func
     + container.escapeExpression(((helper = (helper = helpers.databaseMsg || (depth0 != null ? depth0.databaseMsg : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"databaseMsg","hash":{},"data":data}) : helper)))
     + "</h1>\n";
 },"3":function(container,depth0,helpers,partials,data) {
-    var stack1, helper, alias1=depth0 != null ? depth0 : (container.nullContext || {});
+    var stack1, helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "        <table class=\"sql-schema-table\" data-table-name=\""
-    + container.escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
-    + "\">\n        <thead>\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.hasSingleRow : depth0),{"name":"if","hash":{},"fn":container.program(4, data, 0),"inverse":container.program(6, data, 0),"data":data})) != null ? stack1 : "")
-    + "        </thead>\n        <tbody>\n"
-    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.columns : depth0),{"name":"each","hash":{},"fn":container.program(8, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
+    + "\">\n        <thead>\n            <th><a href=\"javascript:void(0)\">"
+    + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
+    + "</a> <span class=\"row-count\">"
+    + alias4(((helper = (helper = helpers.rowsMsg || (depth0 != null ? depth0.rowsMsg : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"rowsMsg","hash":{},"data":data}) : helper)))
+    + "</span></th>\n        </thead>\n        <tbody>\n"
+    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.columns : depth0),{"name":"each","hash":{},"fn":container.program(4, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "        </tbody>\n        </table>\n";
 },"4":function(container,depth0,helpers,partials,data) {
-    var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
-
-  return "            <th><a href=\"javascript:void(0)\">"
-    + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
-    + "</a> <span class=\"row-count\">"
-    + alias4(((helper = (helper = helpers.rowCount || (depth0 != null ? depth0.rowCount : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"rowCount","hash":{},"data":data}) : helper)))
-    + " "
-    + alias4(((helper = (helper = helpers.rowMsg || (depth0 != null ? depth0.rowMsg : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"rowMsg","hash":{},"data":data}) : helper)))
-    + "</span></th>\n";
-},"6":function(container,depth0,helpers,partials,data) {
-    var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
-
-  return "            <th><a href=\"javascript:void(0)\">"
-    + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
-    + "</a> <span class=\"row-count\">"
-    + alias4(((helper = (helper = helpers.rowCount || (depth0 != null ? depth0.rowCount : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"rowCount","hash":{},"data":data}) : helper)))
-    + " "
-    + alias4(((helper = (helper = helpers.rowsMsg || (depth0 != null ? depth0.rowsMsg : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"rowsMsg","hash":{},"data":data}) : helper)))
-    + "</span></th>\n";
-},"8":function(container,depth0,helpers,partials,data) {
     var stack1, helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "            <tr><td>\n            "
     + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
     + " "
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.pk : depth0),{"name":"if","hash":{},"fn":container.program(9, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.pk : depth0),{"name":"if","hash":{},"fn":container.program(5, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + " <span class=\"column-type-wrap\"><span class=\"schema-column-type\">"
     + alias4(((helper = (helper = helpers.type || (depth0 != null ? depth0.type : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"type","hash":{},"data":data}) : helper)))
     + "</span></span>\n            </td></tr>\n";
-},"9":function(container,depth0,helpers,partials,data) {
+},"5":function(container,depth0,helpers,partials,data) {
     return "<span class=\"schema-pk\">(PK)</span>";
-},"11":function(container,depth0,helpers,partials,data) {
+},"7":function(container,depth0,helpers,partials,data) {
     var helper;
 
   return "        <h1>"
     + container.escapeExpression(((helper = (helper = helpers.resultsMsg || (depth0 != null ? depth0.resultsMsg : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"resultsMsg","hash":{},"data":data}) : helper)))
     + "</h1>\n";
-},"13":function(container,depth0,helpers,partials,data) {
+},"9":function(container,depth0,helpers,partials,data) {
     var stack1, alias1=depth0 != null ? depth0 : (container.nullContext || {});
 
   return "        <table class=\"sql-result-table\">\n        <thead>\n"
-    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.columns : depth0),{"name":"each","hash":{},"fn":container.program(14, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.columns : depth0),{"name":"each","hash":{},"fn":container.program(10, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "        </thead>\n        <tbody>\n"
-    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.values : depth0),{"name":"each","hash":{},"fn":container.program(16, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.values : depth0),{"name":"each","hash":{},"fn":container.program(12, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "        </tbody>\n        </table>\n";
-},"14":function(container,depth0,helpers,partials,data) {
+},"10":function(container,depth0,helpers,partials,data) {
     return "            <th>"
     + container.escapeExpression(container.lambda(depth0, depth0))
     + "</th>\n";
-},"16":function(container,depth0,helpers,partials,data) {
+},"12":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "            <tr>\n"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.result : depth0),{"name":"each","hash":{},"fn":container.program(17, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.result : depth0),{"name":"each","hash":{},"fn":container.program(13, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "            </tr>\n";
-},"17":function(container,depth0,helpers,partials,data) {
+},"13":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = (helpers.isNull || (depth0 && depth0.isNull) || helpers.helperMissing).call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.data : depth0),{"name":"isNull","hash":{},"fn":container.program(18, data, 0),"inverse":container.program(20, data, 0),"data":data})) != null ? stack1 : "");
-},"18":function(container,depth0,helpers,partials,data) {
+  return ((stack1 = (helpers.isNull || (depth0 && depth0.isNull) || helpers.helperMissing).call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.data : depth0),{"name":"isNull","hash":{},"fn":container.program(14, data, 0),"inverse":container.program(16, data, 0),"data":data})) != null ? stack1 : "");
+},"14":function(container,depth0,helpers,partials,data) {
     return "                        <td>NULL</td>\n";
-},"20":function(container,depth0,helpers,partials,data) {
+},"16":function(container,depth0,helpers,partials,data) {
     var helper;
 
   return "                        <td>"
@@ -91,8 +73,8 @@ window["Handlebars"]["templates"]["sql-results"] = Handlebars.template({"1":func
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.tables : depth0),{"name":"if","hash":{},"fn":container.program(1, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.tables : depth0),{"name":"each","hash":{},"fn":container.program(3, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.results : depth0),{"name":"if","hash":{},"fn":container.program(11, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.results : depth0),{"name":"each","hash":{},"fn":container.program(13, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.results : depth0),{"name":"if","hash":{},"fn":container.program(7, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.results : depth0),{"name":"each","hash":{},"fn":container.program(9, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "</div>\n</body>\n</html>\n";
 },"useData":true});;
 var SQLTester = function SQLTester(options) {
@@ -131,7 +113,6 @@ SQLTester.Util = {
             return {
                 name: table,
                 rowCount: rowCount,
-                hasSingleRow: rowCount === 1, // lame, for handlebars :(
                 columns: v.map(function (v) {
                     return {
                         cid: v[0],
@@ -1074,10 +1055,12 @@ window.SQLOutput = Backbone.View.extend({
         var output = Handlebars.templates["sql-results"]({
             tables: tables,
             results: results,
+            // I18N: Appears in the SQL course
             databaseMsg: i18n._("Database Schema"),
+            // I18N: Appears in database header in the SQL course
             resultsMsg: i18n._("Query results"),
-            rowMsg: i18n._("row"),
-            rowsMsg: i18n._("rows")
+            // I18N: Appears in database header in the SQL course
+            rowsMsg: i18n.ngettext("%(num)s row", "%(num)s rows", rowCount)
         });
 
         var doc = this.getDocument();

--- a/build/tmpl/sql-results.js
+++ b/build/tmpl/sql-results.js
@@ -7,78 +7,60 @@ window["Handlebars"]["templates"]["sql-results"] = Handlebars.template({"1":func
     + container.escapeExpression(((helper = (helper = helpers.databaseMsg || (depth0 != null ? depth0.databaseMsg : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"databaseMsg","hash":{},"data":data}) : helper)))
     + "</h1>\n";
 },"3":function(container,depth0,helpers,partials,data) {
-    var stack1, helper, alias1=depth0 != null ? depth0 : (container.nullContext || {});
+    var stack1, helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "        <table class=\"sql-schema-table\" data-table-name=\""
-    + container.escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
-    + "\">\n        <thead>\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.hasSingleRow : depth0),{"name":"if","hash":{},"fn":container.program(4, data, 0),"inverse":container.program(6, data, 0),"data":data})) != null ? stack1 : "")
-    + "        </thead>\n        <tbody>\n"
-    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.columns : depth0),{"name":"each","hash":{},"fn":container.program(8, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
+    + "\">\n        <thead>\n            <th><a href=\"javascript:void(0)\">"
+    + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
+    + "</a> <span class=\"row-count\">"
+    + alias4(((helper = (helper = helpers.rowsMsg || (depth0 != null ? depth0.rowsMsg : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"rowsMsg","hash":{},"data":data}) : helper)))
+    + "</span></th>\n        </thead>\n        <tbody>\n"
+    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.columns : depth0),{"name":"each","hash":{},"fn":container.program(4, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "        </tbody>\n        </table>\n";
 },"4":function(container,depth0,helpers,partials,data) {
-    var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
-
-  return "            <th><a href=\"javascript:void(0)\">"
-    + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
-    + "</a> <span class=\"row-count\">"
-    + alias4(((helper = (helper = helpers.rowCount || (depth0 != null ? depth0.rowCount : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"rowCount","hash":{},"data":data}) : helper)))
-    + " "
-    + alias4(((helper = (helper = helpers.rowMsg || (depth0 != null ? depth0.rowMsg : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"rowMsg","hash":{},"data":data}) : helper)))
-    + "</span></th>\n";
-},"6":function(container,depth0,helpers,partials,data) {
-    var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
-
-  return "            <th><a href=\"javascript:void(0)\">"
-    + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
-    + "</a> <span class=\"row-count\">"
-    + alias4(((helper = (helper = helpers.rowCount || (depth0 != null ? depth0.rowCount : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"rowCount","hash":{},"data":data}) : helper)))
-    + " "
-    + alias4(((helper = (helper = helpers.rowsMsg || (depth0 != null ? depth0.rowsMsg : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"rowsMsg","hash":{},"data":data}) : helper)))
-    + "</span></th>\n";
-},"8":function(container,depth0,helpers,partials,data) {
     var stack1, helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "            <tr><td>\n            "
     + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
     + " "
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.pk : depth0),{"name":"if","hash":{},"fn":container.program(9, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.pk : depth0),{"name":"if","hash":{},"fn":container.program(5, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + " <span class=\"column-type-wrap\"><span class=\"schema-column-type\">"
     + alias4(((helper = (helper = helpers.type || (depth0 != null ? depth0.type : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"type","hash":{},"data":data}) : helper)))
     + "</span></span>\n            </td></tr>\n";
-},"9":function(container,depth0,helpers,partials,data) {
+},"5":function(container,depth0,helpers,partials,data) {
     return "<span class=\"schema-pk\">(PK)</span>";
-},"11":function(container,depth0,helpers,partials,data) {
+},"7":function(container,depth0,helpers,partials,data) {
     var helper;
 
   return "        <h1>"
     + container.escapeExpression(((helper = (helper = helpers.resultsMsg || (depth0 != null ? depth0.resultsMsg : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"resultsMsg","hash":{},"data":data}) : helper)))
     + "</h1>\n";
-},"13":function(container,depth0,helpers,partials,data) {
+},"9":function(container,depth0,helpers,partials,data) {
     var stack1, alias1=depth0 != null ? depth0 : (container.nullContext || {});
 
   return "        <table class=\"sql-result-table\">\n        <thead>\n"
-    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.columns : depth0),{"name":"each","hash":{},"fn":container.program(14, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.columns : depth0),{"name":"each","hash":{},"fn":container.program(10, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "        </thead>\n        <tbody>\n"
-    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.values : depth0),{"name":"each","hash":{},"fn":container.program(16, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.values : depth0),{"name":"each","hash":{},"fn":container.program(12, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "        </tbody>\n        </table>\n";
-},"14":function(container,depth0,helpers,partials,data) {
+},"10":function(container,depth0,helpers,partials,data) {
     return "            <th>"
     + container.escapeExpression(container.lambda(depth0, depth0))
     + "</th>\n";
-},"16":function(container,depth0,helpers,partials,data) {
+},"12":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "            <tr>\n"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.result : depth0),{"name":"each","hash":{},"fn":container.program(17, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.result : depth0),{"name":"each","hash":{},"fn":container.program(13, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "            </tr>\n";
-},"17":function(container,depth0,helpers,partials,data) {
+},"13":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = (helpers.isNull || (depth0 && depth0.isNull) || helpers.helperMissing).call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.data : depth0),{"name":"isNull","hash":{},"fn":container.program(18, data, 0),"inverse":container.program(20, data, 0),"data":data})) != null ? stack1 : "");
-},"18":function(container,depth0,helpers,partials,data) {
+  return ((stack1 = (helpers.isNull || (depth0 && depth0.isNull) || helpers.helperMissing).call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.data : depth0),{"name":"isNull","hash":{},"fn":container.program(14, data, 0),"inverse":container.program(16, data, 0),"data":data})) != null ? stack1 : "");
+},"14":function(container,depth0,helpers,partials,data) {
     return "                        <td>NULL</td>\n";
-},"20":function(container,depth0,helpers,partials,data) {
+},"16":function(container,depth0,helpers,partials,data) {
     var helper;
 
   return "                        <td>"
@@ -91,7 +73,7 @@ window["Handlebars"]["templates"]["sql-results"] = Handlebars.template({"1":func
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.tables : depth0),{"name":"if","hash":{},"fn":container.program(1, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.tables : depth0),{"name":"each","hash":{},"fn":container.program(3, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.results : depth0),{"name":"if","hash":{},"fn":container.program(11, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.results : depth0),{"name":"each","hash":{},"fn":container.program(13, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.results : depth0),{"name":"if","hash":{},"fn":container.program(7, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.results : depth0),{"name":"each","hash":{},"fn":container.program(9, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "</div>\n</body>\n</html>\n";
 },"useData":true});;

--- a/js/output/sql/sql-output.js
+++ b/js/output/sql/sql-output.js
@@ -397,10 +397,15 @@ window.SQLOutput = Backbone.View.extend({
         var output = Handlebars.templates["sql-results"]({
             tables: tables,
             results: results,
+            // I18N: Appears in the SQL course
             databaseMsg: i18n._("Database Schema"),
+            // I18N: Appears in database header in the SQL course
             resultsMsg: i18n._("Query results"),
-            rowMsg: i18n._("row"),
-            rowsMsg: i18n._("rows"),
+            // I18N: Appears in database header in the SQL course
+            rowsMsg: i18n.ngettext(
+                         "%(num)s row",
+                         "%(num)s rows",
+                         rowCount)
         });
 
         var doc = this.getDocument();

--- a/js/output/sql/sql-tester.js
+++ b/js/output/sql/sql-tester.js
@@ -37,7 +37,6 @@ SQLTester.Util = {
             return {
                 name: table,
                 rowCount: rowCount,
-                hasSingleRow: rowCount === 1, // lame, for handlebars :(
                 columns: v.map(function(v) {
                     return {
                         cid: v[0],

--- a/tmpl/sql-results.handlebars
+++ b/tmpl/sql-results.handlebars
@@ -91,11 +91,7 @@ table.sql-schema-table .row-count {
     {{#each tables}}
         <table class="sql-schema-table" data-table-name="{{name}}">
         <thead>
-        {{#if hasSingleRow}}
-            <th><a href="javascript:void(0)">{{name}}</a> <span class="row-count">{{rowCount}} {{rowMsg}}</span></th>
-        {{else}}
-            <th><a href="javascript:void(0)">{{name}}</a> <span class="row-count">{{rowCount}} {{rowsMsg}}</span></th>
-        {{/if}}
+            <th><a href="javascript:void(0)">{{name}}</a> <span class="row-count">{{rowsMsg}}</span></th>
         </thead>
         <tbody>
         {{#each columns}}


### PR DESCRIPTION
### High-level description of the change

"X row/rows" string is not pluralized properly for translators. This change is trying to fix that by using `i18n.ngettext`. But so far it does not seem to work. The SQL output is broken (blank page) in the current commit. I am not sure this approach works in handlebars?

### Are there performance implications for this change?

Probably not.

### Have you added tests to cover this new/updated code?

No, not sure how to test this change. It is notable though that even though the SQL output is currently broken (I see a blank screen in SQL output window), the tests are happily passing.

### Risks involved
Not sure if ngettext can work in this context. 

### Are there any dependencies or blockers for merging this?

No.

### How can we verify that this change works?

Translators should see a single string "%(num)s row" on Crowdin instead of two separate strings "row" and "rows".