### PR TITLE
Add more learner-friendly explanation and missing test for ambiguous column error

### DIFF
--- a/build/js/live-editor.output_sql.js
+++ b/build/js/live-editor.output_sql.js
@@ -846,8 +846,7 @@ window.SQLOutput = Backbone.View.extend({
             // Note(danielhollas): Added a more helpful text as a separate string
             // to preserve existing translations.
             // I18N: This Oh Noes message follows "Ambiguous column name" SQL error
-            // I18N: Keep the space at the beginning of string.
-            errorMessage += " " + i18n._("Multiple tables that you're joining " + "contain a column with that name. To use that column in your query, " + "specify the table of the column. Example: firstTable.\"%(colName)s\"", { colName: colName });
+            errorMessage += " " + i18n._("Multiple tables that you're joining " + "contain a column with that name. Specify the name of the table that " + "contains the column, using the format \"tableName.columnName\".");
         }
         var unknownColStr = "no such column:";
         var unknownColError = sqliteError.indexOf(unknownColStr) > -1;

--- a/build/js/live-editor.output_sql.js
+++ b/build/js/live-editor.output_sql.js
@@ -843,6 +843,11 @@ window.SQLOutput = Backbone.View.extend({
         if (ambColError) {
             var colName = errorMessage.split(ambColStr)[1].trim();
             errorMessage = i18n._("Ambiguous column name \"%(colName)s\".", { colName: colName });
+            // Note(danielhollas): Added a more helpful text as a separate string
+            // to preserve existing translations.
+            // I18N: This Oh Noes message follows "Ambiguous column name" SQL error
+            // I18N: Keep the space at the beginning of string.
+            errorMessage += " " + i18n._("Multiple tables that you're joining " + "contain a column with that name. To use that column in your query, " + "specify the table of the column. Example: firstTable.\"%(colName)s\"", { colName: colName });
         }
         var unknownColStr = "no such column:";
         var unknownColError = sqliteError.indexOf(unknownColStr) > -1;

--- a/demos/simple/sql.html
+++ b/demos/simple/sql.html
@@ -38,8 +38,8 @@
         " *   - students\n" +
         " *   - student_grades\n"+
         " */\n" +
-        "CREATE TABLE students (id INTEGER PRIMARY KEY AUTOINCREMENT, name char, grade_year int NOT NULL);\n" +
-        "CREATE TABLE student_grades (id INTEGER, grade int, FOREIGN KEY (id) REFERENCES students(id));\n\n" +
+        "CREATE TABLE students (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, grade_year INTEGER NOT NULL);\n" +
+        "CREATE TABLE student_grades (id INTEGER, grade INTEGER, FOREIGN KEY (id) REFERENCES students(id));\n\n" +
         "-- Insert some data\n" +
         "INSERT INTO students VALUES (1, \"Brian\", 3);\n" +
         "INSERT INTO students VALUES (2, \"kamil\", 4);\n" +

--- a/js/output/sql/sql-output.js
+++ b/js/output/sql/sql-output.js
@@ -102,6 +102,14 @@ window.SQLOutput = Backbone.View.extend({
             const colName = errorMessage.split(ambColStr)[1].trim();
             errorMessage = i18n._("Ambiguous column name \"%(colName)s\".",
                 {colName});
+            // Note(danielhollas): Added a more helpful text as a separate string
+            // to preserve existing translations.
+            // I18N: This Oh Noes message follows "Ambiguous column name" SQL error
+            // I18N: Keep the space at the beginning of string.
+            errorMessage += " " + i18n._("Multiple tables that you're joining " +
+               "contain a column with that name. To use that column in your query, " +
+               "specify the table of the column. Example: firstTable.\"%(colName)s\"",
+                {colName});
         }
         const unknownColStr = "no such column:";
         const unknownColError = sqliteError.indexOf(unknownColStr) > -1;

--- a/js/output/sql/sql-output.js
+++ b/js/output/sql/sql-output.js
@@ -105,11 +105,9 @@ window.SQLOutput = Backbone.View.extend({
             // Note(danielhollas): Added a more helpful text as a separate string
             // to preserve existing translations.
             // I18N: This Oh Noes message follows "Ambiguous column name" SQL error
-            // I18N: Keep the space at the beginning of string.
             errorMessage += " " + i18n._("Multiple tables that you're joining " +
-               "contain a column with that name. To use that column in your query, " +
-               "specify the table of the column. Example: firstTable.\"%(colName)s\"",
-                {colName});
+               "contain a column with that name. Specify the name of the table that " +
+               "contains the column, using the format \"tableName.columnName\".");
         }
         const unknownColStr = "no such column:";
         const unknownColError = sqliteError.indexOf(unknownColStr) > -1;

--- a/tests/output/sql/output_test.js
+++ b/tests/output/sql/output_test.js
@@ -124,6 +124,15 @@ describe("Linting", function() {
         "INSERT INTO character_episodes VALUES (2, 'Rick');" +
         "SELECT * FROM characters LEFT OUTER JOIN character_episodes ON " +
         "id = characterId");
+    failingTest("Ambiguous column name when joining",
+	"CREATE TABLE students (id INTEGER, name TEXT);" +
+	"CREATE TABLE student_grades (id INTEGER, grade INTEGER);" +
+	"INSERT INTO students VALUES (1, \"Brian\");" +
+	"INSERT INTO student_grades VALUES (1, 95);" +
+	"SELECT id FROM students INNER JOIN student_grades on students.id = student_grades.id;",
+	["Ambiguous column name \"id\". Multiple tables that you're joining " +
+         "contain a column with that name. To use that column in your query, " +
+         "specify the table of the column. Example: firstTable.\"id\""]);
 
     // NOT NULL constraint
     test("NOT NULL constraints enabled",

--- a/tests/output/sql/output_test.js
+++ b/tests/output/sql/output_test.js
@@ -131,8 +131,8 @@ describe("Linting", function() {
 	"INSERT INTO student_grades VALUES (1, 95);" +
 	"SELECT id FROM students INNER JOIN student_grades on students.id = student_grades.id;",
 	["Ambiguous column name \"id\". Multiple tables that you're joining " +
-         "contain a column with that name. To use that column in your query, " +
-         "specify the table of the column. Example: firstTable.\"id\""]);
+         "contain a column with that name. Specify the name of the table that " +
+         "contains the column, using the format \"tableName.columnName\""]);
 
     // NOT NULL constraint
     test("NOT NULL constraints enabled",


### PR DESCRIPTION
### High-level description of change

This PR is a followup on #717, adding a more detailed explanation to a rather cryptic ambiguous column error. I also added a missing test.

### Are there performance implications for this change?

No.

### Have you added tests to cover this new/updated code?

I added a missing test.

### Risks involved
To avoid deleting existing translations, I added the new message as a separate string.
It looks a bit ugly in the code but is translator-friendly (I checked that more than 8 lang translated the error already). But LMK if you want to change it, it's not a deal-breaker.

### Are there any dependencies or blockers for merging this?

No.

### How can we verify that this change works?

The following code triggers the error at http://localhost:8000/demos/simple/sql.html
```sql
CREATE TABLE students (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, grade_year INTEGER NOT NULL);
CREATE TABLE student_grades (id INTEGER, grade INTEGER);
INSERT INTO students VALUES (1, "Brian", 3);
INSERT INTO student_grades VALUES (1, 95);
SELECT id FROM students INNER JOIN student_grades on students.id = student_grades.id;
```
![image](https://user-images.githubusercontent.com/9539441/78512354-10e4e680-77a4-11ea-85e6-03f540ce1039.png)
