### PR TITLE
Fix and correctly pluralize row/rows DB header.

### DIFF
--- a/build/js/live-editor.output_sql.js
+++ b/build/js/live-editor.output_sql.js
@@ -7,78 +7,60 @@ window["Handlebars"]["templates"]["sql-results"] = Handlebars.template({"1":func
     + container.escapeExpression(((helper = (helper = helpers.databaseMsg || (depth0 != null ? depth0.databaseMsg : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"databaseMsg","hash":{},"data":data}) : helper)))
     + "</h1>\n";
 },"3":function(container,depth0,helpers,partials,data) {
-    var stack1, helper, alias1=depth0 != null ? depth0 : (container.nullContext || {});
+    var stack1, helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "        <table class=\"sql-schema-table\" data-table-name=\""
-    + container.escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
-    + "\">\n        <thead>\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.hasSingleRow : depth0),{"name":"if","hash":{},"fn":container.program(4, data, 0),"inverse":container.program(6, data, 0),"data":data})) != null ? stack1 : "")
-    + "        </thead>\n        <tbody>\n"
-    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.columns : depth0),{"name":"each","hash":{},"fn":container.program(8, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
+    + "\">\n        <thead>\n            <th><a href=\"javascript:void(0)\">"
+    + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
+    + "</a> <span class=\"row-count\">"
+    + alias4(((helper = (helper = helpers.rowsMsg || (depth0 != null ? depth0.rowsMsg : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"rowsMsg","hash":{},"data":data}) : helper)))
+    + "</span></th>\n        </thead>\n        <tbody>\n"
+    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.columns : depth0),{"name":"each","hash":{},"fn":container.program(4, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "        </tbody>\n        </table>\n";
 },"4":function(container,depth0,helpers,partials,data) {
-    var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
-
-  return "            <th><a href=\"javascript:void(0)\">"
-    + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
-    + "</a> <span class=\"row-count\">"
-    + alias4(((helper = (helper = helpers.rowCount || (depth0 != null ? depth0.rowCount : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"rowCount","hash":{},"data":data}) : helper)))
-    + " "
-    + alias4(((helper = (helper = helpers.rowMsg || (depth0 != null ? depth0.rowMsg : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"rowMsg","hash":{},"data":data}) : helper)))
-    + "</span></th>\n";
-},"6":function(container,depth0,helpers,partials,data) {
-    var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
-
-  return "            <th><a href=\"javascript:void(0)\">"
-    + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
-    + "</a> <span class=\"row-count\">"
-    + alias4(((helper = (helper = helpers.rowCount || (depth0 != null ? depth0.rowCount : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"rowCount","hash":{},"data":data}) : helper)))
-    + " "
-    + alias4(((helper = (helper = helpers.rowsMsg || (depth0 != null ? depth0.rowsMsg : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"rowsMsg","hash":{},"data":data}) : helper)))
-    + "</span></th>\n";
-},"8":function(container,depth0,helpers,partials,data) {
     var stack1, helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "            <tr><td>\n            "
     + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
     + " "
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.pk : depth0),{"name":"if","hash":{},"fn":container.program(9, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.pk : depth0),{"name":"if","hash":{},"fn":container.program(5, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + " <span class=\"column-type-wrap\"><span class=\"schema-column-type\">"
     + alias4(((helper = (helper = helpers.type || (depth0 != null ? depth0.type : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"type","hash":{},"data":data}) : helper)))
     + "</span></span>\n            </td></tr>\n";
-},"9":function(container,depth0,helpers,partials,data) {
+},"5":function(container,depth0,helpers,partials,data) {
     return "<span class=\"schema-pk\">(PK)</span>";
-},"11":function(container,depth0,helpers,partials,data) {
+},"7":function(container,depth0,helpers,partials,data) {
     var helper;
 
   return "        <h1>"
     + container.escapeExpression(((helper = (helper = helpers.resultsMsg || (depth0 != null ? depth0.resultsMsg : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"resultsMsg","hash":{},"data":data}) : helper)))
     + "</h1>\n";
-},"13":function(container,depth0,helpers,partials,data) {
+},"9":function(container,depth0,helpers,partials,data) {
     var stack1, alias1=depth0 != null ? depth0 : (container.nullContext || {});
 
   return "        <table class=\"sql-result-table\">\n        <thead>\n"
-    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.columns : depth0),{"name":"each","hash":{},"fn":container.program(14, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.columns : depth0),{"name":"each","hash":{},"fn":container.program(10, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "        </thead>\n        <tbody>\n"
-    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.values : depth0),{"name":"each","hash":{},"fn":container.program(16, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.values : depth0),{"name":"each","hash":{},"fn":container.program(12, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "        </tbody>\n        </table>\n";
-},"14":function(container,depth0,helpers,partials,data) {
+},"10":function(container,depth0,helpers,partials,data) {
     return "            <th>"
     + container.escapeExpression(container.lambda(depth0, depth0))
     + "</th>\n";
-},"16":function(container,depth0,helpers,partials,data) {
+},"12":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "            <tr>\n"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.result : depth0),{"name":"each","hash":{},"fn":container.program(17, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.result : depth0),{"name":"each","hash":{},"fn":container.program(13, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "            </tr>\n";
-},"17":function(container,depth0,helpers,partials,data) {
+},"13":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = (helpers.isNull || (depth0 && depth0.isNull) || helpers.helperMissing).call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.data : depth0),{"name":"isNull","hash":{},"fn":container.program(18, data, 0),"inverse":container.program(20, data, 0),"data":data})) != null ? stack1 : "");
-},"18":function(container,depth0,helpers,partials,data) {
+  return ((stack1 = (helpers.isNull || (depth0 && depth0.isNull) || helpers.helperMissing).call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.data : depth0),{"name":"isNull","hash":{},"fn":container.program(14, data, 0),"inverse":container.program(16, data, 0),"data":data})) != null ? stack1 : "");
+},"14":function(container,depth0,helpers,partials,data) {
     return "                        <td>NULL</td>\n";
-},"20":function(container,depth0,helpers,partials,data) {
+},"16":function(container,depth0,helpers,partials,data) {
     var helper;
 
   return "                        <td>"
@@ -91,8 +73,8 @@ window["Handlebars"]["templates"]["sql-results"] = Handlebars.template({"1":func
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.tables : depth0),{"name":"if","hash":{},"fn":container.program(1, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.tables : depth0),{"name":"each","hash":{},"fn":container.program(3, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.results : depth0),{"name":"if","hash":{},"fn":container.program(11, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.results : depth0),{"name":"each","hash":{},"fn":container.program(13, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.results : depth0),{"name":"if","hash":{},"fn":container.program(7, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.results : depth0),{"name":"each","hash":{},"fn":container.program(9, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "</div>\n</body>\n</html>\n";
 },"useData":true});;
 var SQLTester = function SQLTester(options) {
@@ -114,6 +96,7 @@ SQLTester.Util = {
      * @return An array of objects with the fields:
      *   - table: string
      *   - rowCount: number
+     *   - rowsMsg: i18n header string for handlebars
      *   - columns: array of object of extra properties on each column
      *      cid, name, type, notnul, dflt_value, pk
      */
@@ -125,13 +108,17 @@ SQLTester.Util = {
 
         tables = tables.map(function (table) {
             var rowCount = SQLTester.Util.getRowCount(db, table);
+            // NOTE(danielhollas): It seems we need to define this var here
+            // so that it's available in handlebars
+            // I18N: SQL table header
+            var rowsMsg = i18n.ngettext("%(num)s row", "%(num)s rows", rowCount);
             var tablesInfoResult = db.exec("PRAGMA table_info(" + table + ")");
             var v = tablesInfoResult[0].values;
             // Return a table object which also contains each column info
             return {
                 name: table,
                 rowCount: rowCount,
-                hasSingleRow: rowCount === 1, // lame, for handlebars :(
+                rowsMsg: rowsMsg,
                 columns: v.map(function (v) {
                     return {
                         cid: v[0],
@@ -1105,9 +1092,7 @@ window.SQLOutput = Backbone.View.extend({
             tables: tables,
             results: results,
             databaseMsg: i18n._("Database Schema"),
-            resultsMsg: i18n._("Query results"),
-            rowMsg: i18n._("row"),
-            rowsMsg: i18n._("rows")
+            resultsMsg: i18n._("Query results")
         });
 
         var doc = this.getDocument();

--- a/build/tmpl/sql-results.js
+++ b/build/tmpl/sql-results.js
@@ -7,78 +7,60 @@ window["Handlebars"]["templates"]["sql-results"] = Handlebars.template({"1":func
     + container.escapeExpression(((helper = (helper = helpers.databaseMsg || (depth0 != null ? depth0.databaseMsg : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"databaseMsg","hash":{},"data":data}) : helper)))
     + "</h1>\n";
 },"3":function(container,depth0,helpers,partials,data) {
-    var stack1, helper, alias1=depth0 != null ? depth0 : (container.nullContext || {});
+    var stack1, helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "        <table class=\"sql-schema-table\" data-table-name=\""
-    + container.escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
-    + "\">\n        <thead>\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.hasSingleRow : depth0),{"name":"if","hash":{},"fn":container.program(4, data, 0),"inverse":container.program(6, data, 0),"data":data})) != null ? stack1 : "")
-    + "        </thead>\n        <tbody>\n"
-    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.columns : depth0),{"name":"each","hash":{},"fn":container.program(8, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
+    + "\">\n        <thead>\n            <th><a href=\"javascript:void(0)\">"
+    + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
+    + "</a> <span class=\"row-count\">"
+    + alias4(((helper = (helper = helpers.rowsMsg || (depth0 != null ? depth0.rowsMsg : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"rowsMsg","hash":{},"data":data}) : helper)))
+    + "</span></th>\n        </thead>\n        <tbody>\n"
+    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.columns : depth0),{"name":"each","hash":{},"fn":container.program(4, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "        </tbody>\n        </table>\n";
 },"4":function(container,depth0,helpers,partials,data) {
-    var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
-
-  return "            <th><a href=\"javascript:void(0)\">"
-    + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
-    + "</a> <span class=\"row-count\">"
-    + alias4(((helper = (helper = helpers.rowCount || (depth0 != null ? depth0.rowCount : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"rowCount","hash":{},"data":data}) : helper)))
-    + " "
-    + alias4(((helper = (helper = helpers.rowMsg || (depth0 != null ? depth0.rowMsg : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"rowMsg","hash":{},"data":data}) : helper)))
-    + "</span></th>\n";
-},"6":function(container,depth0,helpers,partials,data) {
-    var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
-
-  return "            <th><a href=\"javascript:void(0)\">"
-    + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
-    + "</a> <span class=\"row-count\">"
-    + alias4(((helper = (helper = helpers.rowCount || (depth0 != null ? depth0.rowCount : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"rowCount","hash":{},"data":data}) : helper)))
-    + " "
-    + alias4(((helper = (helper = helpers.rowsMsg || (depth0 != null ? depth0.rowsMsg : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"rowsMsg","hash":{},"data":data}) : helper)))
-    + "</span></th>\n";
-},"8":function(container,depth0,helpers,partials,data) {
     var stack1, helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "            <tr><td>\n            "
     + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
     + " "
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.pk : depth0),{"name":"if","hash":{},"fn":container.program(9, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.pk : depth0),{"name":"if","hash":{},"fn":container.program(5, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + " <span class=\"column-type-wrap\"><span class=\"schema-column-type\">"
     + alias4(((helper = (helper = helpers.type || (depth0 != null ? depth0.type : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"type","hash":{},"data":data}) : helper)))
     + "</span></span>\n            </td></tr>\n";
-},"9":function(container,depth0,helpers,partials,data) {
+},"5":function(container,depth0,helpers,partials,data) {
     return "<span class=\"schema-pk\">(PK)</span>";
-},"11":function(container,depth0,helpers,partials,data) {
+},"7":function(container,depth0,helpers,partials,data) {
     var helper;
 
   return "        <h1>"
     + container.escapeExpression(((helper = (helper = helpers.resultsMsg || (depth0 != null ? depth0.resultsMsg : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"resultsMsg","hash":{},"data":data}) : helper)))
     + "</h1>\n";
-},"13":function(container,depth0,helpers,partials,data) {
+},"9":function(container,depth0,helpers,partials,data) {
     var stack1, alias1=depth0 != null ? depth0 : (container.nullContext || {});
 
   return "        <table class=\"sql-result-table\">\n        <thead>\n"
-    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.columns : depth0),{"name":"each","hash":{},"fn":container.program(14, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.columns : depth0),{"name":"each","hash":{},"fn":container.program(10, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "        </thead>\n        <tbody>\n"
-    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.values : depth0),{"name":"each","hash":{},"fn":container.program(16, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.values : depth0),{"name":"each","hash":{},"fn":container.program(12, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "        </tbody>\n        </table>\n";
-},"14":function(container,depth0,helpers,partials,data) {
+},"10":function(container,depth0,helpers,partials,data) {
     return "            <th>"
     + container.escapeExpression(container.lambda(depth0, depth0))
     + "</th>\n";
-},"16":function(container,depth0,helpers,partials,data) {
+},"12":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "            <tr>\n"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.result : depth0),{"name":"each","hash":{},"fn":container.program(17, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.result : depth0),{"name":"each","hash":{},"fn":container.program(13, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "            </tr>\n";
-},"17":function(container,depth0,helpers,partials,data) {
+},"13":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = (helpers.isNull || (depth0 && depth0.isNull) || helpers.helperMissing).call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.data : depth0),{"name":"isNull","hash":{},"fn":container.program(18, data, 0),"inverse":container.program(20, data, 0),"data":data})) != null ? stack1 : "");
-},"18":function(container,depth0,helpers,partials,data) {
+  return ((stack1 = (helpers.isNull || (depth0 && depth0.isNull) || helpers.helperMissing).call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.data : depth0),{"name":"isNull","hash":{},"fn":container.program(14, data, 0),"inverse":container.program(16, data, 0),"data":data})) != null ? stack1 : "");
+},"14":function(container,depth0,helpers,partials,data) {
     return "                        <td>NULL</td>\n";
-},"20":function(container,depth0,helpers,partials,data) {
+},"16":function(container,depth0,helpers,partials,data) {
     var helper;
 
   return "                        <td>"
@@ -91,7 +73,7 @@ window["Handlebars"]["templates"]["sql-results"] = Handlebars.template({"1":func
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.tables : depth0),{"name":"if","hash":{},"fn":container.program(1, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.tables : depth0),{"name":"each","hash":{},"fn":container.program(3, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.results : depth0),{"name":"if","hash":{},"fn":container.program(11, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.results : depth0),{"name":"each","hash":{},"fn":container.program(13, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.results : depth0),{"name":"if","hash":{},"fn":container.program(7, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.results : depth0),{"name":"each","hash":{},"fn":container.program(9, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "</div>\n</body>\n</html>\n";
 },"useData":true});;

--- a/js/output/sql/sql-output.js
+++ b/js/output/sql/sql-output.js
@@ -438,8 +438,6 @@ window.SQLOutput = Backbone.View.extend({
             results: results,
             databaseMsg: i18n._("Database Schema"),
             resultsMsg: i18n._("Query results"),
-            rowMsg: i18n._("row"),
-            rowsMsg: i18n._("rows"),
         });
 
         var doc = this.getDocument();

--- a/js/output/sql/sql-tester.js
+++ b/js/output/sql/sql-tester.js
@@ -18,6 +18,7 @@ SQLTester.Util = {
      * @return An array of objects with the fields:
      *   - table: string
      *   - rowCount: number
+     *   - rowsMsg: i18n header string for handlebars
      *   - columns: array of object of extra properties on each column
      *      cid, name, type, notnul, dflt_value, pk
      */
@@ -31,13 +32,20 @@ SQLTester.Util = {
 
         tables = tables.map(function(table) {
             var rowCount = SQLTester.Util.getRowCount(db, table);
+            // NOTE(danielhollas): It seems we need to define this var here
+            // so that it's available in handlebars
+            // I18N: SQL table header
+            var rowsMsg = i18n.ngettext(
+                    "%(num)s row",
+                    "%(num)s rows",
+                    rowCount);
             var tablesInfoResult = db.exec("PRAGMA table_info(" + table + ")");
             var v = tablesInfoResult[0].values;
             // Return a table object which also contains each column info
             return {
                 name: table,
                 rowCount: rowCount,
-                hasSingleRow: rowCount === 1, // lame, for handlebars :(
+                rowsMsg: rowsMsg,
                 columns: v.map(function(v) {
                     return {
                         cid: v[0],

--- a/tmpl/sql-results.handlebars
+++ b/tmpl/sql-results.handlebars
@@ -91,11 +91,7 @@ table.sql-schema-table .row-count {
     {{#each tables}}
         <table class="sql-schema-table" data-table-name="{{name}}">
         <thead>
-        {{#if hasSingleRow}}
-            <th><a href="javascript:void(0)">{{name}}</a> <span class="row-count">{{rowCount}} {{rowMsg}}</span></th>
-        {{else}}
-            <th><a href="javascript:void(0)">{{name}}</a> <span class="row-count">{{rowCount}} {{rowsMsg}}</span></th>
-        {{/if}}
+            <th><a href="javascript:void(0)">{{name}}</a> <span class="row-count">{{rowsMsg}}</span></th>
         </thead>
         <tbody>
         {{#each columns}}


### PR DESCRIPTION
### High-level description of change

It seems that #691, which made the "row/rows" strings translatable, did not work as intended. On the current live site, the header contains only a number, without "rows"

![image](https://user-images.githubusercontent.com/9539441/78840920-5ac80980-79fc-11ea-8823-79866aad7c5b.png)

I'm not entirely sure what's wrong with the original approach, but I think it's connected to the fact the the `rowsMsg` is accessed inside the `{{each tables}}` context in the Handlebars template. When I moved `{{rowsMsg}}` elsewhere, it did render correctly.

This PR hopefully fixes that and also fixes the pluralization of the i18nized string.

### Are there performance implications for this change?

No.

### Have you added tests to cover this new/updated code?

No, I tested visually on the SQL test page. I am nervous though that while testing different approaches, I sometimes broke the SQL output page (it was blank), but the tests were happily passing away. It seems the current tests only check the Oh Noes errors, but not the actual output of the SQL page. I don't know how difficult would it be to add such a test. 

### Risks involved

We need to carefully check that this worked in prod after deploy.

### Are there any dependencies or blockers for merging this?

No.

### How can we verify that this change works?

Verify that the table headers show "1 row" or "X rows". We also should verify that the generated Crowdin strings are correct. I will take care of that.
