### PR TITLE
Fix HTML editor resize bug

### DIFF
--- a/build/js/live-editor.ui.js
+++ b/build/js/live-editor.ui.js
@@ -2092,7 +2092,7 @@ window.LiveEditor = Backbone.View.extend({
 
     updateCanvasSize: function updateCanvasSize(width, height) {
         width = width || this.defaultOutputWidth;
-        height = height || this.defaultOutputHeight;
+        height = height || this.editorHeight || this.defaultOutputHeight;
 
         this.$el.find(this.dom.CANVAS_WRAP).width(width);
         this.$el.find(this.dom.ALL_OUTPUT).height(height);

--- a/js/live-editor.js
+++ b/js/live-editor.js
@@ -1402,7 +1402,7 @@ window.LiveEditor = Backbone.View.extend({
 
     updateCanvasSize: function(width, height) {
         width = width || this.defaultOutputWidth;
-        height = height || this.defaultOutputHeight;
+        height = height || this.editorHeight || this.defaultOutputHeight;
 
         this.$el.find(this.dom.CANVAS_WRAP).width(width);
         this.$el.find(this.dom.ALL_OUTPUT).height(height);


### PR DESCRIPTION
### High-level description of change
Fixes #738
When the HTML editor is drag-resized by the user, the height always returns to 400. This PR attempts to fix that by setting the default height to the current height if it exists when resizing.

### Are there performance implications for this change?
No. This is a very small change.

### Have you added tests to cover this new/updated code?
No. No intended functionality was changed.

### Risks involved
This change shouldn't carry any risks as long as the editor height is always either falsey or a number, or a height is passed to the function. From what I can tell, the only time the height _isn't_ passed to the function is when the user resizes it.

### Are there any dependencies or blockers for merging this?
No.

### How can we verify that this change works?
I can't verify that this doesn't break anything on page load because the horizontal resize code appears to be in a different repo, but I tested the updated function in production by pasting it into the Javascript console on any resized webpage program, then resizing it.
```js
window.LiveEditor.prototype.updateCanvasSize = function updateCanvasSize(width, height) {
    width = width || this.defaultOutputWidth;
    height = height || this.editorHeight || this.defaultOutputHeight;

    this.$el.find(this.dom.CANVAS_WRAP).width(width);
    this.$el.find(this.dom.ALL_OUTPUT).height(height);

    // Set the editor height to be the same as the canvas height
    this.$el.find(this.dom.EDITOR).height(this.editorHeight || height);

    this.trigger("canvasSizeUpdated", {
        width: width,
        height: height
    });
}
```