### PR TITLE
[🔥AUDIT🔥] Fix comment in CSS file

### DIFF
--- a/build/css/live-editor.ui.css
+++ b/build/css/live-editor.ui.css
@@ -307,7 +307,7 @@
 }
 
 .scratchpad-playbar .scratchpad-playbar-play .ui-button-text {
-    // override default of .4em so play button will fit in an iframe
+    /* override default of .4em so play button will fit in an iframe */
     padding: 5px;
 }
 

--- a/css/ui/style.css
+++ b/css/ui/style.css
@@ -141,7 +141,7 @@
 }
 
 .scratchpad-playbar .scratchpad-playbar-play .ui-button-text {
-    // override default of .4em so play button will fit in an iframe
+    /* override default of .4em so play button will fit in an iframe */
     padding: 5px;
 }
 


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
In webapp we import CSS for live-editor directly into some of our .less files which means that less doens't convert any '//' style comments to valid CSS comments.  This hasn't been an issue with webpack, but vite uses a different version of postcss which throws an error when it encounters the invalid comment.

Issue: FEI-4343

## Test plan:
- make this change to the CSS file in node_modules/live-editor/build
- in webapp load http://localhost:8088/computing/computer-programming/programming/coloring/pp/project-whats-for-dinner
- see that it loads using "Vitejs Directly" without issues