### PR TITLE
Fix Security error when using `getImage` in editor

### DIFF
--- a/build/js/live-editor.output_pjs_deps.js
+++ b/build/js/live-editor.output_pjs_deps.js
@@ -14932,6 +14932,11 @@
       pimg = new PImage();
       var img = document.createElement('img');
 
+      // Fixes a security error when we attempt to extract image data from this
+      // canvas.
+      // https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/crossOrigin
+      img.crossOrigin = "anonymous";
+
       pimg.sourceImg = img;
 
       img.onload = (function(aImage, aPImage, aCallback) {


### PR DESCRIPTION
## Summary:

Modern browsers keep track of where images are loaded from. That origin information follows an image even if it is loaded into a canvas. When images are loaded into a canvas, if their origin is not the same as the canvas' document origin and the image hasn't been loaded with proper CORS headers, the canvas becomes tainted. Once tainted, the image data cannot be exfiltrated from the canvas.

This PR updates the `processing-js` submodule dependency to a commit where `<img />` elements used to load images are properly set up for CORS. This will hopefully fix the Security issue when trying to take a screenshot of a scratchpad that has used images.

## Test plan: