### PR TITLE
[🔥AUDIT🔥] Wait for output frame to be active before beginning execution.

### DIFF
--- a/build/js/live-editor.output.js
+++ b/build/js/live-editor.output.js
@@ -490,9 +490,11 @@ window.LiveEditorOutput = Backbone.View.extend({
         var parentWindow = window.parent;
         // Ignore any attempts to send a message to the same window
         if (parentWindow === window) {
+            console.log("NOT SENDING DUE TO PARENT === WINDOW");
             return;
         }
 
+        console.log("postParent", data, parentWindow, parentWindow.origin);
         parentWindow.postMessage(typeof data === "string" ? data : JSON.stringify(data), parentWindow.origin);
     },
 

--- a/build/js/live-editor.output.js
+++ b/build/js/live-editor.output.js
@@ -344,6 +344,9 @@ window.LiveEditorOutput = Backbone.View.extend({
         this.lintWarnings.timestamp = 0;
 
         this.bind();
+
+        // let the parent know we're up and running
+        this.notifyActive();
     },
 
     render: function render() {
@@ -402,9 +405,6 @@ window.LiveEditorOutput = Backbone.View.extend({
 
         this.frameSource = event.source;
         this.frameOrigin = event.origin;
-
-        // let the parent know we're up and running
-        this.notifyActive();
 
         // filter out events that are objects
         // currently the only messages that contain objects are messages

--- a/build/js/live-editor.output.js
+++ b/build/js/live-editor.output.js
@@ -403,9 +403,6 @@ window.LiveEditorOutput = Backbone.View.extend({
     handleMessage: function handleMessage(event) {
         var data;
 
-        this.frameSource = event.source;
-        this.frameOrigin = event.origin;
-
         // filter out events that are objects
         // currently the only messages that contain objects are messages
         // being sent by Poster instances being used by the iframeOverlay
@@ -490,21 +487,13 @@ window.LiveEditorOutput = Backbone.View.extend({
 
     // Send a message back to the parent frame
     postParent: function postParent(data) {
-        // If there is no frameSource (e.g. we're not embedded in another page)
-        // Then we don't need to care about sending the messages anywhere!
-        if (this.frameSource) {
-            var parentWindow = this.frameSource;
-            // Ignore any attempts to send a message to the same window
-            // NOTE(jeresig): Ideally we'd queue up these messages until
-            // we have a valid frameSource & frameOrigin and then send all
-            // the messages at that time. In practice this doesn't seem to
-            // be a problem, however.
-            if (this.frameSource === window) {
-                return;
-            }
-
-            parentWindow.postMessage(typeof data === "string" ? data : JSON.stringify(data), this.frameOrigin);
+        var parentWindow = window.parent;
+        // Ignore any attempts to send a message to the same window
+        if (parentWindow === window) {
+            return;
         }
+
+        parentWindow.postMessage(typeof data === "string" ? data : JSON.stringify(data), parentWindow.origin);
     },
 
     notifyActive: _.once(function () {

--- a/build/js/live-editor.output.js
+++ b/build/js/live-editor.output.js
@@ -490,11 +490,9 @@ window.LiveEditorOutput = Backbone.View.extend({
         var parentWindow = window.parent;
         // Ignore any attempts to send a message to the same window
         if (parentWindow === window) {
-            console.log("NOT SENDING DUE TO PARENT === WINDOW");
             return;
         }
 
-        console.log("postParent", data, parentWindow, parentWindow.origin);
         parentWindow.postMessage(typeof data === "string" ? data : JSON.stringify(data), parentWindow.origin);
     },
 

--- a/build/js/live-editor.ui.js
+++ b/build/js/live-editor.ui.js
@@ -972,11 +972,6 @@ window.LiveEditor = Backbone.View.extend({
         this.handleMessagesBound = this.handleMessages.bind(this);
         $(window).on("message", this.handleMessagesBound);
 
-        $el.find("#output-frame").on("load", function () {
-            _this.outputState = "clean";
-            _this.markDirty();
-        });
-
         // Whenever the user changes code, execute the code
         this.editor.on("change", function () {
             _this.markDirty();
@@ -1835,6 +1830,13 @@ window.LiveEditor = Backbone.View.extend({
             // this, or at least make it more clear that the data coming in may
             // be unsanitized.
             this.record.log.apply(this.record, data.log);
+        }
+
+        // If the frame is ready to begin execution, we can start sending it
+        // code to run.
+        if (data.active) {
+            this.outputState = "clean";
+            this.markDirty();
         }
     },
 

--- a/js/live-editor.js
+++ b/js/live-editor.js
@@ -246,11 +246,6 @@ window.LiveEditor = Backbone.View.extend({
         this.handleMessagesBound = this.handleMessages.bind(this);
         $(window).on("message", this.handleMessagesBound);
 
-        $el.find("#output-frame").on("load", () => {
-            this.outputState = "clean";
-            this.markDirty();
-        });
-
         // Whenever the user changes code, execute the code
         this.editor.on("change", () => {
             this.markDirty();
@@ -1135,6 +1130,13 @@ window.LiveEditor = Backbone.View.extend({
             // this, or at least make it more clear that the data coming in may
             // be unsanitized.
             this.record.log.apply(this.record, data.log);
+        }
+
+        // If the frame is ready to begin execution, we can start sending it
+        // code to run.
+        if (data.active) {
+            this.outputState = "clean";
+            this.markDirty();
         }
     },
 

--- a/js/output/shared/output.js
+++ b/js/output/shared/output.js
@@ -33,6 +33,9 @@ window.LiveEditorOutput = Backbone.View.extend({
         this.lintWarnings.timestamp = 0;
 
         this.bind();
+
+        // let the parent know we're up and running
+        this.notifyActive();
     },
 
     render: function() {
@@ -92,9 +95,6 @@ window.LiveEditorOutput = Backbone.View.extend({
 
         this.frameSource = event.source;
         this.frameOrigin = event.origin;
-
-        // let the parent know we're up and running
-        this.notifyActive();
 
         // filter out events that are objects
         // currently the only messages that contain objects are messages

--- a/js/output/shared/output.js
+++ b/js/output/shared/output.js
@@ -56,7 +56,7 @@ window.LiveEditorOutput = Backbone.View.extend({
             output: this,
             type: outputType,
             enableLoopProtect: enableLoopProtect,
-            loopProtectTimeouts: loopProtectTimeouts
+            loopProtectTimeouts: loopProtectTimeouts,
         });
     },
 
@@ -93,9 +93,6 @@ window.LiveEditorOutput = Backbone.View.extend({
     handleMessage: function(event) {
         var data;
 
-        this.frameSource = event.source;
-        this.frameOrigin = event.origin;
-
         // filter out events that are objects
         // currently the only messages that contain objects are messages
         // being sent by Poster instances being used by the iframeOverlay
@@ -117,7 +114,7 @@ window.LiveEditorOutput = Backbone.View.extend({
             }
             var loopProtectTimeouts = {
                 initialTimeout: 2000,
-                frameTimeout: 500
+                frameTimeout: 500,
             };
             if (data.loopProtectTimeouts != null) {
                 loopProtectTimeouts = data.loopProtectTimeouts;
@@ -180,23 +177,15 @@ window.LiveEditorOutput = Backbone.View.extend({
 
     // Send a message back to the parent frame
     postParent: function(data) {
-        // If there is no frameSource (e.g. we're not embedded in another page)
-        // Then we don't need to care about sending the messages anywhere!
-        if (this.frameSource) {
-            let parentWindow = this.frameSource;
-            // Ignore any attempts to send a message to the same window
-            // NOTE(jeresig): Ideally we'd queue up these messages until
-            // we have a valid frameSource & frameOrigin and then send all
-            // the messages at that time. In practice this doesn't seem to
-            // be a problem, however.
-            if (this.frameSource === window) {
-                return;
-            }
-
-            parentWindow.postMessage(
-                typeof data === "string" ? data : JSON.stringify(data),
-                this.frameOrigin);
+        const parentWindow = window.parent;
+        // Ignore any attempts to send a message to the same window
+        if (parentWindow === window) {
+            return;
         }
+
+        parentWindow.postMessage(
+            typeof data === "string" ? data : JSON.stringify(data),
+            parentWindow.origin);
     },
 
     notifyActive: _.once(function() {
@@ -266,7 +255,7 @@ window.LiveEditorOutput = Backbone.View.extend({
             code: userCode,
             errors: [],
             assertions: [],
-            warnings: []
+            warnings: [],
         };
 
         var skip = noLint && this.firstLint;
@@ -380,7 +369,7 @@ window.LiveEditorOutput = Backbone.View.extend({
      */
     phoneHome: function() {
         this.postParent({
-            results: this.results
+            results: this.results,
         });
     },
 

--- a/js/output/shared/output.js
+++ b/js/output/shared/output.js
@@ -180,9 +180,11 @@ window.LiveEditorOutput = Backbone.View.extend({
         const parentWindow = window.parent;
         // Ignore any attempts to send a message to the same window
         if (parentWindow === window) {
+            console.log("NOT SENDING DUE TO PARENT === WINDOW");
             return;
         }
 
+        console.log("postParent", data, parentWindow, parentWindow.origin);
         parentWindow.postMessage(
             typeof data === "string" ? data : JSON.stringify(data),
             parentWindow.origin);

--- a/js/output/shared/output.js
+++ b/js/output/shared/output.js
@@ -180,11 +180,9 @@ window.LiveEditorOutput = Backbone.View.extend({
         const parentWindow = window.parent;
         // Ignore any attempts to send a message to the same window
         if (parentWindow === window) {
-            console.log("NOT SENDING DUE TO PARENT === WINDOW");
             return;
         }
 
-        console.log("postParent", data, parentWindow, parentWindow.origin);
         parentWindow.postMessage(
             typeof data === "string" ? data : JSON.stringify(data),
             parentWindow.origin);


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
We were waiting for the frame to load, which was happening too early with our recent move to React. We should wait for the frame to tell us we're active.

Issue: FEI-4639

## Test plan:
I imported this into Webapp and loaded up:
http://localhost:8088/computing/computer-programming/html-css-js/html-js-dom-modification/pc/challenge-avatar-attributes

I added in some logging and confirmed that we now wait for the "active" event to come back before we send off code to be executed. In my limited testing so far this seems to be very successful!