### PR TITLE
[🔥AUDIT🔥] Use a catch-all origin for postParent.

### DIFF
--- a/build/js/live-editor.output.js
+++ b/build/js/live-editor.output.js
@@ -493,7 +493,7 @@ window.LiveEditorOutput = Backbone.View.extend({
             return;
         }
 
-        parentWindow.postMessage(typeof data === "string" ? data : JSON.stringify(data), parentWindow.origin);
+        parentWindow.postMessage(typeof data === "string" ? data : JSON.stringify(data), "*");
     },
 
     notifyActive: _.once(function () {

--- a/js/output/shared/output.js
+++ b/js/output/shared/output.js
@@ -185,7 +185,7 @@ window.LiveEditorOutput = Backbone.View.extend({
 
         parentWindow.postMessage(
             typeof data === "string" ? data : JSON.stringify(data),
-            parentWindow.origin);
+            "*");
     },
 
     notifyActive: _.once(function() {


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
It turns out that in a cross-origin frame context we aren't allowed to access the "origin" variable, so we just have to use "*" instead, but this should be fine!

Issue: FEI-4639

## Test plan:
Will test this out on a ZND/Staging.