### PR TITLE
Only set window.KAInfiniteLoopProtect once in webpage-output.js

### DIFF
--- a/build/js/live-editor.output_webpage.js
+++ b/build/js/live-editor.output_webpage.js
@@ -579,11 +579,7 @@ window.WebpageOutput = Backbone.View.extend({
         // Set up infinite loop protection
         this.loopProtector = new LoopProtector(this.infiniteLoopCallback.bind(this));
         this.$frame.contentWindow.KAInfiniteLoopProtect = this.loopProtector.KAInfiniteLoopProtect;
-        // In case frame didn't load (like in IE10), this adds it
-        //  once the frame has loaded
-        this.$frame.addEventListener("load", (function () {
-            this.$frame.contentWindow.KAInfiniteLoopProtect = this.loopProtector.KAInfiniteLoopProtect;
-        }).bind(this));
+
         // Do this at the end so variables I add to the global scope stay
         // i.e.  KAInfiniteLoopProtect
         this.stateScrubber = new StateScrubber(this.$frame.contentWindow);
@@ -877,8 +873,6 @@ window.WebpageOutput = Backbone.View.extend({
         this.KA_INFINITE_LOOP = false;
         this.foundRunTimeError = false;
         this.frameDoc.open();
-        // It's necessary in FF/IE to redefine it here
-        this.$frame.contentWindow.KAInfiniteLoopProtect = this.loopProtector.KAInfiniteLoopProtect;
         this.$frame.contentWindow.addEventListener("error", (function () {
             this.foundRunTimeError = true;
         }).bind(this));

--- a/js/output/webpage/webpage-output.js
+++ b/js/output/webpage/webpage-output.js
@@ -26,12 +26,7 @@ window.WebpageOutput = Backbone.View.extend({
         this.loopProtector = new LoopProtector(this.infiniteLoopCallback.bind(this));
         this.$frame.contentWindow.KAInfiniteLoopProtect =
             this.loopProtector.KAInfiniteLoopProtect;
-        // In case frame didn't load (like in IE10), this adds it
-        //  once the frame has loaded
-        this.$frame.addEventListener("load", function () {
-            this.$frame.contentWindow.KAInfiniteLoopProtect =
-                this.loopProtector.KAInfiniteLoopProtect;
-        }.bind(this));
+
         // Do this at the end so variables I add to the global scope stay
         // i.e.  KAInfiniteLoopProtect
         this.stateScrubber = new StateScrubber(this.$frame.contentWindow);
@@ -332,9 +327,6 @@ window.WebpageOutput = Backbone.View.extend({
         this.KA_INFINITE_LOOP = false;
         this.foundRunTimeError = false;
         this.frameDoc.open();
-        // It's necessary in FF/IE to redefine it here
-        this.$frame.contentWindow.KAInfiniteLoopProtect =
-                this.loopProtector.KAInfiniteLoopProtect;
         this.$frame.contentWindow.addEventListener("error", function () {
             this.foundRunTimeError = true;
         }.bind(this));


### PR DESCRIPTION
### High-level description of change

This fixes an issue where sometimes the browser will report a `TypeError` because `window.KAInfiniteLoopProtect` was readonly.  The reason why it was readonly is because `StateScrubber` locks down all of the properties on `window`.  I'm not sure how the webpage environment was working before this changing (probably a timing thing).

### Are there performance implications for this change?

There are no performance implications for this change.

### Have you added tests to cover this new/updated code?

I have not added any new tests for the changes.  It's hard to write an automated test for given live-editor's current testing infrastructure.

### Risks involved

None that I can think of.

### Are there any dependencies or blockers for merging this?

No

### How can we verify that this change works?

I verified this by:
- applying these changes to services/static/node_modules/live-editor/build/js/live-editor.output.js directly
- restarting vitejs in hotel
- loading http://localhost:8090/computer-programming/new/webpage
- modifying the HTML code in the editor and seeing the iframe update
- I tested this in Chrome, Safari, and Firefox
